### PR TITLE
fix/documentation-archive-page-section-article-title-truncted-issue

### DIFF
--- a/assets/build/frontend.asset.php
+++ b/assets/build/frontend.asset.php
@@ -1,1 +1,5 @@
+<<<<<<< Updated upstream
 <?php return array('dependencies' => array(), 'version' => '0022b05841da55c0df98');
+=======
+<?php return array('dependencies' => array(), 'version' => 'f16c62340637dc2329b3');
+>>>>>>> Stashed changes

--- a/assets/build/frontend.asset.php
+++ b/assets/build/frontend.asset.php
@@ -1,5 +1,1 @@
-<<<<<<< Updated upstream
 <?php return array('dependencies' => array(), 'version' => '0022b05841da55c0df98');
-=======
-<?php return array('dependencies' => array(), 'version' => 'f16c62340637dc2329b3');
->>>>>>> Stashed changes

--- a/assets/build/frontend.css
+++ b/assets/build/frontend.css
@@ -491,18 +491,18 @@ body.single.single-docs .content-area {
 .wedocs-shortcode-wrap ul.wedocs-docs-list ul.wedocs-doc-sections > li > svg {
   width: 16px;
   cursor: pointer;
+  margin-left: 10px;
 }
 .wedocs-shortcode-wrap ul.wedocs-docs-list ul.wedocs-doc-sections > li > svg.active {
   transform: rotate(180deg);
 }
 .wedocs-shortcode-wrap ul.wedocs-docs-list ul.wedocs-doc-sections ul.children {
-  margin: 0;
+  margin: 6px 0;
   padding-left: 24px;
-  margin-bottom: 6px;
 }
 .wedocs-shortcode-wrap ul.wedocs-docs-list ul.wedocs-doc-sections ul.children > li {
   list-style: circle;
-  line-height: 36px;
+  line-height: 1.5;
 }
 .wedocs-shortcode-wrap ul.wedocs-docs-list ul.wedocs-doc-sections ul.children:not(.active) {
   display: none;
@@ -554,7 +554,7 @@ body.single.single-docs .content-area {
 .wedocs-shortcode-wrap.pro ul.wedocs-doc-sections > li a {
   display: flex;
   font-size: 18px;
-  line-height: 40px;
+  line-height: 1.5;
   text-decoration: none;
 }
 .wedocs-shortcode-wrap.pro ul.wedocs-doc-sections > li a:not(:hover) {

--- a/src/assets/less/frontend.less
+++ b/src/assets/less/frontend.less
@@ -323,6 +323,7 @@ body.single.single-docs .content-area {
                 > svg {
                     width: 16px;
                     cursor: pointer;
+                    margin-left: 10px;
 
                     &.active {
                         transform: rotate(180deg);
@@ -331,13 +332,12 @@ body.single.single-docs .content-area {
             }
 
             ul.children {
-                margin: 0;
+                margin: 6px 0;
                 padding-left: 24px;
-                margin-bottom: 6px;
 
                 > li {
                     list-style: circle;
-                    line-height: 36px;
+                    line-height: 1.5;
                 }
 
                 &:not(.active) {
@@ -416,7 +416,7 @@ body.single.single-docs .content-area {
                 a {
                     display: flex;
                     font-size: 18px;
-                    line-height: 40px;
+                    line-height: 1.5;
                     text-decoration: none;
 
                     &:not(:hover) {

--- a/templates/shortcode.php
+++ b/templates/shortcode.php
@@ -33,7 +33,7 @@
                                 $children_docs = get_page_children( $section->ID, $all_wp_pages );
                                 $post_title    = wedocs_apply_short_content(
                                     __( $section->post_title, 'wedocs' ),
-                                    $col > 1 ? 25 : 60
+                                    $col > 1 ? 60 : 160
                                 );
 
                                 $collapse_section_articles = wedocs_get_general_settings( 'collapse_articles', 'off' );
@@ -61,7 +61,7 @@
                                         <?php foreach ( $children_docs as $article ) : ?>
                                             <li>
                                                 <a href="<?php echo get_permalink( $article->ID ); ?>" target='_blank'>
-                                                    <?php echo esc_html( wedocs_apply_short_content( $article->post_title, $col > 1 ? 30 : 80 ) ); ?>
+                                                    <?php echo esc_html( wedocs_apply_short_content( $article->post_title, $col > 1 ? 60 : 160 ) ); ?>
                                                 </a>
                                             </li>
                                         <?php endforeach; ?>


### PR DESCRIPTION
### Fix documentation sections & articles title truncted issue on archive page.

Dependency: [#46](https://github.com/weDevsOfficial/wedocs-pro/pull/46)
Issue: [#42](https://github.com/weDevsOfficial/wedocs-pro/issues/42)