### PR TITLE
fix/template-overriding-isn't-working-from-site-theme

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -26,7 +26,7 @@ function wedocs_get_template_part( $slug, $name = '', $args = array() ) {
 
     // Look in yourtheme/wedocs/slug-name.php and yourtheme/wedocs/slug.php.
     $template_path = ! empty( $name ) ? "{$slug}-{$name}.php" : "{$slug}.php";
-    $template      = locate_template( [ $wedocs->template_path() . $template_path ] );
+    $template      = locate_template( [ $wedocs->theme_dir_path() . $template_path ] );
 
     $template_path = apply_filters( 'wedocs_set_template_path', $wedocs->plugin_path() . '/templates', $template, $args );
 


### PR DESCRIPTION
### Fix wedocs sidebar template not override perfectly from site theme.

Issue: [#176](https://github.com/weDevsOfficial/wedocs-plugin/issues/176)