### PR TITLE
Handle hash router.

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -411,9 +411,10 @@
 
   $( function () {
     // Handle hash router.
-    if ( window.location.hash ) {
-      window.location = window.location.pathname;
-    }
+      // This is commented out because it causes the page to reload when the hash is present.
+    // if ( window.location.hash ) {
+    //   window.location = window.location.pathname;
+    // }
 
     // Handle navigation caret.
     if ( ! anchestorItem?.classList.contains( 'wd-state-open' ) ) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,7 @@ if ( ! isProduction ) {
       writeToDisk: true,
     },
     allowedHosts: 'all',
-    host: 'localhost',
+    host: 'wedocs.test',
     port: 8886,
     proxy: {
       '/assets/build': {


### PR DESCRIPTION
To fix the page reload when the hash is present in the frontend URL.
This will fix this [Issue](https://github.com/weDevsOfficial/wedocs-pro/issues/110)
[Dependency](https://github.com/weDevsOfficial/wedocs-pro/pull/112)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Disabled page reload functionality when a hash is present in the URL to enhance user experience.
  
- **Configuration Changes**
	- Updated development server host address to improve accessibility during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->