### PR TITLE
🛠️ [FIX] Upgrade-to-Pro content getting overlapped

### DIFF
--- a/src/components/ProPreviews/common/Overlay.js
+++ b/src/components/ProPreviews/common/Overlay.js
@@ -2,7 +2,7 @@ import UpgradePopup from './UpgradePopup';
 
 const Overlay = ( { classes } ) => {
   return (
-    <div className={ `${classes} pro-content-overlay w-full h-full absolute top-0 left-0 z-[9999] bg-[#00000080]` }>
+    <div className={ `${classes} pro-content-overlay w-full h-full absolute top-0 left-0 bg-[#00000080]` }>
       <UpgradePopup />
     </div>
   );

--- a/src/components/Settings/GeneralSettings.js
+++ b/src/components/Settings/GeneralSettings.js
@@ -26,12 +26,12 @@ const GeneralSettings = ( {
   }, [ generalSettingsData ] );
 
   return (
-    <section>
+      <section>
       <div className="shadow sm:rounded-md">
         <div className="bg-white sm:rounded-md min-h-[500px]">
           <div className="section-heading py-4 px-8 sm:px-8 sm:py-4">
             <h2 className="text-gray-900 font-medium text-lg">
-              { __( 'General', 'wedocs' ) }
+              {__('General', 'wedocs')}
             </h2>
           </div>
           <hr className="h-px !bg-gray-200 border-0 dark:!bg-gray-200" />
@@ -40,39 +40,39 @@ const GeneralSettings = ( {
               <div className="settings-content flex items-center justify-between">
                 <div className="settings-field-heading md:min-w-[300px] flex items-center space-x-2 flex-1">
                   <label
-                    className="block text-sm font-medium text-gray-600"
-                    id="headlessui-listbox-label-15"
-                    data-headlessui-state="open"
+                      className="block text-sm font-medium text-gray-600"
+                      id="headlessui-listbox-label-15"
+                      data-headlessui-state="open"
                   >
-                    { __( 'weDocs Home', 'wedocs' ) }
+                    {__('weDocs Home', 'wedocs')}
                   </label>
                 </div>
                 <div className="settings-field w-full max-w-[490px] mt-1 ml-auto flex-2">
                   <div className="relative">
                     <SelectBox
-                      name="docs_home"
-                      setSettings={ setSettings }
-                      settingsData={ settingsData }
-                      settingsPanel={ generalSettings }
+                        name="docs_home"
+                        setSettings={setSettings}
+                        settingsData={settingsData}
+                        settingsPanel={generalSettings}
                     />
                   </div>
                 </div>
               </div>
               <div className="settings-description w-full max-w-[490px] ml-auto mt-1">
                 <p className="text-sm text-[#6B7280]">
-                  { __(
-                    'Select the documentation Home page, where the shortcode [wedocs] ',
-                    'wedocs'
-                  ) }
-                  <a
-                    href="https://github.com/tareq1988/wedocs-plugin/wiki/Using-Shortcodes"
-                    target="_blank"
-                    className="text-indigo-700 underline underline-offset-2 !shadow-none"
-                    rel="noreferrer"
-                  >
-                    { __( 'shortcode', 'wedocs' ) }
+                  {__(
+                      'Select the documentation Home page, where the shortcode [wedocs] ',
+                      'wedocs'
+                  )}
+                    <a
+                        href="https://github.com/tareq1988/wedocs-plugin/wiki/Using-Shortcodes"
+                        target="_blank"
+                        className="text-indigo-700 underline underline-offset-2 !shadow-none"
+                        rel="noreferrer"
+                    >
+                    {__('shortcode', 'wedocs')}
                   </a>
-                  { __( ' is used.', 'wedocs' ) }
+                    {__(' is used.', 'wedocs')}
                 </p>
               </div>
             </div>
@@ -81,80 +81,80 @@ const GeneralSettings = ( {
               <div className="settings-content flex items-center justify-between">
                 <div className="settings-heading md:min-w-[300px] flex items-center space-x-2 flex-1">
                   <label
-                    className="block text-sm font-medium text-gray-600"
-                    id="headlessui-listbox-label-15"
-                    data-headlessui-state="open"
+                      className="block text-sm font-medium text-gray-600"
+                      id="headlessui-listbox-label-15"
+                      data-headlessui-state="open"
                   >
-                    { __( 'Email Feedback on Article', 'wedocs' ) }
+                    {__('Email Feedback on Article', 'wedocs')}
                   </label>
                   <div
-                    className="tooltip cursor-pointer ml-2 z-[9999]"
-                    data-tip={ __(
-                      'Invite readers to share their thoughts through an email feedback form',
-                      'wedocs'
-                    ) }
+                      className="tooltip cursor-pointer ml-2 z-[9999]"
+                      data-tip={__(
+                          'Invite readers to share their thoughts through an email feedback form',
+                          'wedocs'
+                      )}
                   >
                     <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="18"
-                      height="18"
-                      fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="18"
+                        height="18"
+                        fill="none"
                     >
                       <path
-                        d="M9.833 12.333H9V9h-.833M9 5.667h.008M16.5 9a7.5 7.5 0 1 1-15 0 7.5 7.5 0 1 1 15 0z"
-                        stroke="#6b7280"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
+                          d="M9.833 12.333H9V9h-.833M9 5.667h.008M16.5 9a7.5 7.5 0 1 1-15 0 7.5 7.5 0 1 1 15 0z"
+                          stroke="#6b7280"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
                       />
                     </svg>
                   </div>
                 </div>
                 <div className="settings-field flex items-center w-full max-w-[490px] ml-auto flex-2">
                   <Switcher
-                    name="email"
-                    settingsPanel={ generalSettings }
-                    settingsData={ settingsData }
-                    setSettings={ setSettings }
-                    panelName={ `general` }
-                    isEnabled={ generalSettings?.email !== 'off' }
+                      name="email"
+                      settingsPanel={generalSettings}
+                      settingsData={settingsData}
+                      setSettings={setSettings}
+                      panelName={`general`}
+                      isEnabled={generalSettings?.email !== 'off'}
                   />
                 </div>
               </div>
             </div>
 
-            { ( generalSettingsData?.email === 'on' ||
-              ! Boolean( generalSettingsData?.email ) ) && (
-              <div className="col-span-4">
+              {(generalSettingsData?.email === 'on' ||
+                  !Boolean(generalSettingsData?.email)) && (
+                  <div className="col-span-4">
                 <div className="settings-content flex items-center justify-between">
                   <div className="settings-field-heading md:min-w-[300px] flex items-center space-x-2 flex-1">
                     <label
-                      className="block text-sm font-medium text-gray-600"
-                      id="headlessui-listbox-label-15"
-                      data-headlessui-state="open"
+                        className="block text-sm font-medium text-gray-600"
+                        id="headlessui-listbox-label-15"
+                        data-headlessui-state="open"
                     >
-                      { __( 'Email Address', 'wedocs' ) }
+                      {__('Email Address', 'wedocs')}
                     </label>
 
                     <div
-                      className="tooltip cursor-pointer ml-2 z-[9999]"
-                      data-tip={ __(
-                        'Enter the email address where you would like to receive feedback',
-                        'wedocs'
-                      ) }
+                        className="tooltip cursor-pointer ml-2 z-[9999]"
+                        data-tip={__(
+                            'Enter the email address where you would like to receive feedback',
+                            'wedocs'
+                        )}
                     >
                       <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="18"
-                        height="18"
-                        fill="none"
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="18"
+                          height="18"
+                          fill="none"
                       >
                         <path
-                          d="M9.833 12.333H9V9h-.833M9 5.667h.008M16.5 9a7.5 7.5 0 1 1-15 0 7.5 7.5 0 1 1 15 0z"
-                          stroke="#6b7280"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
+                            d="M9.833 12.333H9V9h-.833M9 5.667h.008M16.5 9a7.5 7.5 0 1 1-15 0 7.5 7.5 0 1 1 15 0z"
+                            stroke="#6b7280"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
                         />
                       </svg>
                     </div>
@@ -162,64 +162,64 @@ const GeneralSettings = ( {
                   <div className="settings-field w-full max-w-[490px] ml-auto flex-2">
                     <div className="relative">
                       <input
-                        type="email"
-                        name="doc_title"
-                        id="doc-title"
-                        placeholder={ __(
-                          'Write your email address',
-                          'wedocs'
-                        ) }
-                        className="w-full !rounded-md !border-gray-300 bg-white !py-1 !pl-3 !pr-10 text-left shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm"
-                        value={ generalSettingsData?.email_to || '' }
-                        onChange={ handleEmailAddress }
+                          type="email"
+                          name="doc_title"
+                          id="doc-title"
+                          placeholder={__(
+                              'Write your email address',
+                              'wedocs'
+                          )}
+                          className="w-full !rounded-md !border-gray-300 bg-white !py-1 !pl-3 !pr-10 text-left shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:text-sm"
+                          value={generalSettingsData?.email_to || ''}
+                          onChange={handleEmailAddress}
                       />
                     </div>
                   </div>
                 </div>
               </div>
-            ) }
+              )}
 
-            <div className="col-span-4">
+              <div className="col-span-4">
               <div className="settings-content flex items-center justify-between">
                 <div className="settings-heading md:min-w-[300px] space-x-2 items-center flex flex-1">
                   <label
-                    className="block text-sm font-medium text-gray-600"
-                    id="headlessui-listbox-label-15"
-                    data-headlessui-state="open"
+                      className="block text-sm font-medium text-gray-600"
+                      id="headlessui-listbox-label-15"
+                      data-headlessui-state="open"
                   >
-                    { __( 'Enable searchbar on docs home', 'wedocs' ) }
+                    {__('Enable searchbar on docs home', 'wedocs')}
                   </label>
                   <div
-                    className="tooltip cursor-pointer ml-2 z-[9999]"
-                    data-tip={ __(
-                      'Enable searchbar on docs homepage, applicable only for those using the [weDocs] shortcode',
-                      'wedocs'
-                    ) }
+                      className="tooltip cursor-pointer ml-2 z-[9999]"
+                      data-tip={__(
+                          'Enable searchbar on docs homepage, applicable only for those using the [weDocs] shortcode',
+                          'wedocs'
+                      )}
                   >
                     <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="18"
-                      height="18"
-                      fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="18"
+                        height="18"
+                        fill="none"
                     >
                       <path
-                        d="M9.833 12.333H9V9h-.833M9 5.667h.008M16.5 9a7.5 7.5 0 1 1-15 0 7.5 7.5 0 1 1 15 0z"
-                        stroke="#6b7280"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
+                          d="M9.833 12.333H9V9h-.833M9 5.667h.008M16.5 9a7.5 7.5 0 1 1-15 0 7.5 7.5 0 1 1 15 0z"
+                          stroke="#6b7280"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
                       />
                     </svg>
                   </div>
                 </div>
                 <div className="settings-field flex items-center w-full max-w-[490px] ml-auto flex-2">
                   <Switcher
-                    name="enable_search"
-                    settingsPanel={ generalSettings }
-                    settingsData={ settingsData }
-                    setSettings={ setSettings }
-                    panelName={ `general` }
-                    isEnabled={ generalSettings?.enable_search !== 'off' }
+                      name="enable_search"
+                      settingsPanel={generalSettings}
+                      settingsData={settingsData}
+                      setSettings={setSettings}
+                      panelName={`general`}
+                      isEnabled={generalSettings?.enable_search !== 'off'}
                   />
                 </div>
               </div>
@@ -229,43 +229,43 @@ const GeneralSettings = ( {
               <div className="settings-content flex items-center justify-between">
                 <div className="settings-heading md:min-w-[300px] space-x-2 items-center flex flex-1">
                   <label
-                    className="block text-sm font-medium text-gray-600"
-                    id="headlessui-listbox-label-15"
-                    data-headlessui-state="open"
+                      className="block text-sm font-medium text-gray-600"
+                      id="headlessui-listbox-label-15"
+                      data-headlessui-state="open"
                   >
-                    { __( 'Helpful Feedback on Article', 'wedocs' ) }
+                    {__('Helpful Feedback on Article', 'wedocs')}
                   </label>
                   <div
-                    className="tooltip cursor-pointer ml-2 z-[9999]"
-                    data-tip={ __(
-                      'Enabling helpful feedback on your article allows readers to provide opinions on your content',
-                      'wedocs'
-                    ) }
+                      className="tooltip cursor-pointer ml-2 z-[9999]"
+                      data-tip={__(
+                          'Enabling helpful feedback on your article allows readers to provide opinions on your content',
+                          'wedocs'
+                      )}
                   >
                     <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="18"
-                      height="18"
-                      fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="18"
+                        height="18"
+                        fill="none"
                     >
                       <path
-                        d="M9.833 12.333H9V9h-.833M9 5.667h.008M16.5 9a7.5 7.5 0 1 1-15 0 7.5 7.5 0 1 1 15 0z"
-                        stroke="#6b7280"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
+                          d="M9.833 12.333H9V9h-.833M9 5.667h.008M16.5 9a7.5 7.5 0 1 1-15 0 7.5 7.5 0 1 1 15 0z"
+                          stroke="#6b7280"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
                       />
                     </svg>
                   </div>
                 </div>
                 <div className="settings-field flex items-center w-full max-w-[490px] ml-auto flex-2">
                   <Switcher
-                    name="helpful"
-                    settingsPanel={ generalSettings }
-                    settingsData={ settingsData }
-                    setSettings={ setSettings }
-                    panelName={ `general` }
-                    isEnabled={ generalSettings?.helpful !== 'off' }
+                      name="helpful"
+                      settingsPanel={generalSettings}
+                      settingsData={settingsData}
+                      setSettings={setSettings}
+                      panelName={`general`}
+                      isEnabled={generalSettings?.helpful !== 'off'}
                   />
                 </div>
               </div>
@@ -275,43 +275,43 @@ const GeneralSettings = ( {
               <div className="settings-content flex items-center justify-between mt-1">
                 <div className="settings-heading md:min-w-[300px] space-x-2 items-center flex flex-1">
                   <label
-                    className="block text-sm font-medium text-gray-600"
-                    id="headlessui-listbox-label-15"
-                    data-headlessui-state="open"
+                      className="block text-sm font-medium text-gray-600"
+                      id="headlessui-listbox-label-15"
+                      data-headlessui-state="open"
                   >
-                    { __( 'Allow Comments on Article', 'wedocs' ) }
+                    {__('Allow Comments on Article', 'wedocs')}
                   </label>
                   <div
-                    className="tooltip cursor-pointer ml-2 z-[9999]"
-                    data-tip={ __(
-                      'Increase reader engagement by turning on comments',
-                      'wedocs'
-                    ) }
+                      className="tooltip cursor-pointer ml-2 z-[9999]"
+                      data-tip={__(
+                          'Increase reader engagement by turning on comments',
+                          'wedocs'
+                      )}
                   >
                     <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="18"
-                      height="18"
-                      fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="18"
+                        height="18"
+                        fill="none"
                     >
                       <path
-                        d="M9.833 12.333H9V9h-.833M9 5.667h.008M16.5 9a7.5 7.5 0 1 1-15 0 7.5 7.5 0 1 1 15 0z"
-                        stroke="#6b7280"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
+                          d="M9.833 12.333H9V9h-.833M9 5.667h.008M16.5 9a7.5 7.5 0 1 1-15 0 7.5 7.5 0 1 1 15 0z"
+                          stroke="#6b7280"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
                       />
                     </svg>
                   </div>
                 </div>
                 <div className="settings-field flex items-center w-full max-w-[490px] ml-auto flex-2">
                   <Switcher
-                    name="comments"
-                    settingsPanel={ generalSettings }
-                    settingsData={ settingsData }
-                    setSettings={ setSettings }
-                    panelName={ `general` }
-                    isEnabled={ generalSettings?.comments === 'on' }
+                      name="comments"
+                      settingsPanel={generalSettings}
+                      settingsData={settingsData}
+                      setSettings={setSettings}
+                      panelName={`general`}
+                      isEnabled={generalSettings?.comments === 'on'}
                   />
                 </div>
               </div>
@@ -321,43 +321,43 @@ const GeneralSettings = ( {
               <div className="settings-content flex items-center justify-between">
                 <div className="settings-heading md:min-w-[300px] space-x-2 items-center flex flex-1">
                   <label
-                    className="block text-sm font-medium text-gray-600"
-                    id="headlessui-listbox-label-15"
-                    data-headlessui-state="open"
+                      className="block text-sm font-medium text-gray-600"
+                      id="headlessui-listbox-label-15"
+                      data-headlessui-state="open"
                   >
-                    { __( 'Allow Article Printing', 'wedocs' ) }
+                    {__('Allow Article Printing', 'wedocs')}
                   </label>
                   <div
-                    className="tooltip cursor-pointer ml-2 z-[9999]"
-                    data-tip={ __(
-                      'Allow users to print articles directly from the website',
-                      'wedocs'
-                    ) }
+                      className="tooltip cursor-pointer ml-2 z-[9999]"
+                      data-tip={__(
+                          'Allow users to print articles directly from the website',
+                          'wedocs'
+                      )}
                   >
                     <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="18"
-                      height="18"
-                      fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="18"
+                        height="18"
+                        fill="none"
                     >
                       <path
-                        d="M9.833 12.333H9V9h-.833M9 5.667h.008M16.5 9a7.5 7.5 0 1 1-15 0 7.5 7.5 0 1 1 15 0z"
-                        stroke="#6b7280"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
+                          d="M9.833 12.333H9V9h-.833M9 5.667h.008M16.5 9a7.5 7.5 0 1 1-15 0 7.5 7.5 0 1 1 15 0z"
+                          stroke="#6b7280"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
                       />
                     </svg>
                   </div>
                 </div>
                 <div className="settings-field flex items-center w-full max-w-[490px] ml-auto flex-2">
                   <Switcher
-                    name="print"
-                    settingsPanel={ generalSettings }
-                    settingsData={ settingsData }
-                    setSettings={ setSettings }
-                    panelName={ `general` }
-                    isEnabled={ generalSettings?.print !== 'off' }
+                      name="print"
+                      settingsPanel={generalSettings}
+                      settingsData={settingsData}
+                      setSettings={setSettings}
+                      panelName={`general`}
+                      isEnabled={generalSettings?.print !== 'off'}
                   />
                 </div>
               </div>


### PR DESCRIPTION
This will fix [this issue](https://github.com/weDevsOfficial/wedocs-pro/issues/81)

This pull request includes a small change to the `Overlay` component in the `src/components/ProPreviews/common/Overlay.js` file. The change removes an unnecessary `z-index` property from the `div` element.

* [`src/components/ProPreviews/common/Overlay.js`](diffhunk://#diff-e79df3e786609fe9bb8bd721868e3e967cce4eff60dfdef3c4fb35a315e5c37fL5-R5): Removed the `z-[9999]` class from the `div` element to simplify the styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the rendering of translatable strings in the settings, enhancing overall readability.

- **Style**
	- Cleaned up formatting and removed unnecessary whitespace in the JSX structure for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->