### PR TITLE
Add .distignore file to exclude dev files from distribution

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,8 @@
+.bablerc.js
+.eslintrc
+.github/
+.prettierrc
+.wordpress-org/
+tailwind.config.js
+postcss.config.js
+webpack.config.js


### PR DESCRIPTION
fixes: [155](https://github.com/weDevsOfficial/wedocs-pro/issues/155)
Introduces a .distignore file to specify files and directories that should be excluded from distribution builds, such as configuration files and development-related folders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a configuration to exclude development and configuration files from distribution packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->