### PR TITLE
Added: Docs, Support, Upgrade to Pro plugin links

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -21,6 +21,11 @@ class Admin {
 
         // Redirect to a new design after trashing a doc
         add_action('load-edit.php', array($this, 'trashed_docs_redirect'));
+
+         // 1. Add links in the installed plugins list page
+        add_filter( 'plugin_action_links_' . plugin_basename(WEDOCS_FILE ), [$this, 'plugin_instalation_page_links'], 10, 3 );
+        // 2. Add links in the plugin install/info popup page
+        add_filter( 'plugins_api_result', [$this, 'plugin_details_popup_links']);
     }
 
     /**
@@ -80,4 +85,40 @@ class Admin {
         $client = new Appsero_Client( 'aa0ffba5-b889-40af-a34c-41fc8f707faa', 'weDocs', WEDOCS_FILE );
         $client->insights()->init();
     }
+
+
+     function plugin_instalation_page_links( $links ) {
+        $pro_link     = '<a href="https://wedocs.co/pricing/" target="_blank" style="font-weight:bold; color:#17b517;">'. esc_html__( 'Upgrade to Pro', 'wedocs' ) .'</a> ';
+        $discount_link = '<a href="https://wedocs.co/pricing/" target="_blank" style="color:#d63638;">'. esc_html__( 'Check Discount', 'wedocs' ) .'</a>';
+        $docs_link = '<a href="https://wedocs.co/docs/" target="_blank">'. esc_html__( 'Docs', 'wedocs' ) .'</a> ';
+        $support_link = '<a href="https://wedocs.co/get-support/" target="_blank">'. esc_html__( 'Get Support', 'wedocs' ) .'</a>';
+        $items = [
+            $docs_link
+        ];
+        if(!is_plugin_active('wedocs-pro/wedocs-pro.php')){
+            $items[]= $pro_link;
+            $items []= $discount_link;
+        }
+        $items[] = $support_link;
+        array_push( $links, ...$items, );
+        return $links;
+    }
+
+    function plugin_details_popup_link( $res, $action, $args ) {
+        if ( isset($res->slug) && $res->slug === 'wedocs' ) {
+            if ( isset( $res->sections['description'] ) ) {
+                $extra_html  = '<p style="margin-top:10px;">';
+                if(!is_plugin_active('wedocs-pro/wedocs-pro.php')){
+                    $extra_html .= '<a href="https://wedocs.co/pricing/" target="_blank" style="margin-right:6px;color:green;">'. esc_html__( 'Upgrade to Pro', 'wedocs' ) .'</a> | ';
+                    $extra_html .= '<a href="https://wedocs.co/pricing/" target="_blank">'. esc_html__( 'Check Discount', 'wedocs' ) .'</a> | ';
+                }
+                $extra_html .= '<a href="https://wedocs.co/docs/" target="_blank">'. esc_html__( 'Docs', 'wedocs' ) .'</a> | ';
+                $extra_html .= '<a href="https://wedocs.co/get-support/" target="_blank">'. esc_html__( 'Get Support', 'wedocs' ) .'</a>';
+                $extra_html .= '</p>';
+                $res->sections['description'] .= $extra_html;
+            }
+        }
+        return $res;
+    }
+
 }

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -89,7 +89,7 @@ class Admin {
 
      function plugin_instalation_page_link( $links ) {
         $pro_link     = '<a href="https://wedocs.co/pricing/" target="_blank" style="font-weight:bold; color:#17b517;">'. esc_html__( 'Upgrade to Pro', 'wedocs' ) .'</a> ';
-        $discount_link = '<a href="https://wedevs.com/coupons/ target="_blank" style="color:#d63638;">'. esc_html__( 'Check Discount', 'wedocs' ) .'</a>';
+        $discount_link = '<a href="https://wedevs.com/coupons/" target="_blank" style="color:#d63638;">'. esc_html__( 'Check Discount', 'wedocs' ) .'</a>';
         $docs_link = '<a href="https://wedocs.co/docs/" target="_blank">'. esc_html__( 'Docs', 'wedocs' ) .'</a> ';
         $support_link = '<a href="https://wedocs.co/get-support/" target="_blank">'. esc_html__( 'Get Support', 'wedocs' ) .'</a>';
         $items = [

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -23,9 +23,9 @@ class Admin {
         add_action('load-edit.php', array($this, 'trashed_docs_redirect'));
 
          // 1. Add links in the installed plugins list page
-        add_filter( 'plugin_action_links_' . plugin_basename(WEDOCS_FILE ), [$this, 'plugin_instalation_page_links'], 10, 3 );
+        add_filter( 'plugin_action_links_' . plugin_basename(WEDOCS_FILE ), [$this, 'plugin_instalation_page_link'], 10, 3 );
         // 2. Add links in the plugin install/info popup page
-        add_filter( 'plugins_api_result', [$this, 'plugin_details_popup_links']);
+        add_filter( 'plugins_api_result', [$this, 'plugin_details_popup_link']);
     }
 
     /**
@@ -87,9 +87,9 @@ class Admin {
     }
 
 
-     function plugin_instalation_page_links( $links ) {
+     function plugin_instalation_page_link( $links ) {
         $pro_link     = '<a href="https://wedocs.co/pricing/" target="_blank" style="font-weight:bold; color:#17b517;">'. esc_html__( 'Upgrade to Pro', 'wedocs' ) .'</a> ';
-        $discount_link = '<a href="https://wedocs.co/pricing/" target="_blank" style="color:#d63638;">'. esc_html__( 'Check Discount', 'wedocs' ) .'</a>';
+        $discount_link = '<a href="https://wedevs.com/coupons/ target="_blank" style="color:#d63638;">'. esc_html__( 'Check Discount', 'wedocs' ) .'</a>';
         $docs_link = '<a href="https://wedocs.co/docs/" target="_blank">'. esc_html__( 'Docs', 'wedocs' ) .'</a> ';
         $support_link = '<a href="https://wedocs.co/get-support/" target="_blank">'. esc_html__( 'Get Support', 'wedocs' ) .'</a>';
         $items = [
@@ -110,7 +110,7 @@ class Admin {
                 $extra_html  = '<p style="margin-top:10px;">';
                 if(!is_plugin_active('wedocs-pro/wedocs-pro.php')){
                     $extra_html .= '<a href="https://wedocs.co/pricing/" target="_blank" style="margin-right:6px;color:green;">'. esc_html__( 'Upgrade to Pro', 'wedocs' ) .'</a> | ';
-                    $extra_html .= '<a href="https://wedocs.co/pricing/" target="_blank">'. esc_html__( 'Check Discount', 'wedocs' ) .'</a> | ';
+                    $extra_html .= '<a href="https://wedevs.com/coupons/" target="_blank">'. esc_html__( 'Check Discount', 'wedocs' ) .'</a> | ';
                 }
                 $extra_html .= '<a href="https://wedocs.co/docs/" target="_blank">'. esc_html__( 'Docs', 'wedocs' ) .'</a> | ';
                 $extra_html .= '<a href="https://wedocs.co/get-support/" target="_blank">'. esc_html__( 'Get Support', 'wedocs' ) .'</a>';

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -25,7 +25,7 @@ class Admin {
          // 1. Add links in the installed plugins list page
         add_filter( 'plugin_action_links_' . plugin_basename(WEDOCS_FILE ), [$this, 'plugin_instalation_page_link'], 10, 3 );
         // 2. Add links in the plugin install/info popup page
-        add_filter( 'plugins_api_result', [$this, 'plugin_details_popup_link']);
+        add_filter( 'plugins_api_result', [$this, 'plugin_details_popup_link'], 10, 3 );
     }
 
     /**


### PR DESCRIPTION
Added: https://github.com/weDevsOfficial/wedocs-pro/issues/166

Added: Docs, Support, Upgrade to Pro plugin links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quick-access links on the Plugins screen: Docs and Get Support for all users; plus Upgrade to Pro and Check Discount when Pro isn’t active.
  * Enhanced the plugin details popup with the same helpful links, making it easier to view docs, request support, and discover upgrade options directly from the details view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->