### PR TITLE
fix: stop the admin doc list loading the whole tree

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -97,9 +97,12 @@ class API {
      * @return \WP_REST_Response
      */
     public function set_comment_count_to_docs_response( $response, $post, $request ) {
-        $post_id                         = $post->ID;
-        $comments_count                  = wp_count_comments( $post_id );
-        $response->data['comment_count'] = $comments_count->approved;
+        // WordPress already keeps `posts.comment_count` in sync with the number of
+        // approved comments (see wp_update_comment_count_now()), and the column is
+        // loaded with the post itself. Reading it costs nothing, whereas
+        // wp_count_comments() fires five COUNT queries per post and is only cached
+        // in-request, so on a large doc tree it dominated the response time.
+        $response->data['comment_count'] = (int) $post->comment_count;
 
         return $response;
     }

--- a/includes/API/API.php
+++ b/includes/API/API.php
@@ -482,6 +482,292 @@ class API extends WP_REST_Controller {
                 ],
             ],
         ] );
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/listing', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_docs_listing' ],
+                'permission_callback' => [ $this, 'listing_permissions_check' ],
+                'args'                => [
+                    'page'     => [
+                        'default'           => 1,
+                        'type'              => 'integer',
+                        'minimum'           => 1,
+                        'sanitize_callback' => 'absint',
+                        'validate_callback' => 'rest_validate_request_arg',
+                    ],
+                    'per_page' => [
+                        'default'           => 20,
+                        'type'              => 'integer',
+                        'minimum'           => 1,
+                        'maximum'           => 100,
+                        'sanitize_callback' => 'absint',
+                        'validate_callback' => 'rest_validate_request_arg',
+                    ],
+                    'search'   => [
+                        'default'           => '',
+                        'type'              => 'string',
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                ],
+            ],
+        ] );
+
+        register_rest_route( $this->namespace, '/' . $this->rest_base . '/children', [
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'get_docs_children' ],
+                'permission_callback' => [ $this, 'listing_permissions_check' ],
+                'args'                => [
+                    'parent' => [
+                        'required'          => true,
+                        'type'              => 'array',
+                        'items'             => [ 'type' => 'integer' ],
+                        'sanitize_callback' => function ( $value ) {
+                            return array_values( array_unique( array_filter( array_map( 'absint', (array) $value ) ) ) );
+                        },
+                    ],
+                ],
+            ],
+        ] );
+    }
+
+    /**
+     * Permission check for the admin listing endpoints.
+     *
+     * Mirrors the capability the weDocs admin menu itself is registered with, so
+     * anyone who can reach the screen can populate it.
+     *
+     * @since 2.4.1
+     *
+     * @return \WP_Error|bool
+     */
+    public function listing_permissions_check() {
+        if ( ! current_user_can( wedocs_get_publish_cap() ) && ! current_user_can( 'edit_docs' ) ) {
+            return new WP_Error(
+                'wedocs_permission_failure',
+                __( 'Unauthorized permission error', 'wedocs' ),
+                [ 'status' => rest_authorization_required_code() ]
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * Statuses the current user is allowed to see in the admin listing.
+     *
+     * @since 2.4.1
+     *
+     * @return array
+     */
+    protected function get_listing_statuses() {
+        $statuses = [ 'publish' ];
+
+        if ( current_user_can( 'edit_docs' ) || current_user_can( wedocs_get_publish_cap() ) ) {
+            $statuses = [ 'publish', 'draft', 'private' ];
+        }
+
+        return $statuses;
+    }
+
+    /**
+     * Shape a doc row for the admin tree.
+     *
+     * Deliberately mirrors the handful of fields the tree reads from the
+     * collection endpoint, so the store can treat both sources identically.
+     *
+     * @since 2.4.1
+     *
+     * @param \WP_Post $post
+     *
+     * @return array
+     */
+    protected function prepare_listing_item( $post ) {
+        return [
+            'id'            => (int) $post->ID,
+            'parent'        => (int) $post->post_parent,
+            'menu_order'    => (int) $post->menu_order,
+            'title'         => [ 'rendered' => get_the_title( $post ) ],
+            'status'        => $post->post_status,
+            'slug'          => $post->post_name,
+            'modified'      => mysql_to_rfc3339( $post->post_modified ),
+            'comment_count' => (int) $post->comment_count,
+            'link'          => get_permalink( $post ),
+            'meta'          => [
+                '_is_vendor_doc' => (string) get_post_meta( $post->ID, '_is_vendor_doc', true ),
+            ],
+        ];
+    }
+
+    /**
+     * Paginated listing of top-level docs, with descendant counts attached.
+     *
+     * The admin tree used to fetch every doc just to render root cards and their
+     * "N sections / N articles" badges. That meant pulling the entire tree — the
+     * dominant cost on large sites. Here the roots are paginated and the counts
+     * come from a single aggregate query, so children are only fetched when a
+     * doc is actually opened.
+     *
+     * @since 2.4.1
+     *
+     * @param \WP_REST_Request $request
+     *
+     * @return \WP_REST_Response
+     */
+    public function get_docs_listing( $request ) {
+        global $wpdb;
+
+        $page     = max( 1, (int) $request['page'] );
+        $per_page = max( 1, (int) $request['per_page'] );
+        $search   = trim( (string) $request['search'] );
+        $statuses = $this->get_listing_statuses();
+
+        $query_args = [
+            'post_type'              => 'docs',
+            'post_status'            => $statuses,
+            'post_parent'            => 0,
+            'posts_per_page'         => $per_page,
+            'paged'                  => $page,
+            'orderby'                => [ 'menu_order' => 'ASC', 'ID' => 'ASC' ],
+            'ignore_sticky_posts'    => true,
+            'no_found_rows'          => false,
+            'update_post_term_cache' => false,
+        ];
+
+        // The tree's search box has always matched titles only, so keep WP_Query
+        // from widening it to post content.
+        $title_search = null;
+
+        if ( '' !== $search ) {
+            $title_search = $search;
+
+            $filter_title_search = function ( $where, $wp_query ) use ( &$filter_title_search, $title_search ) {
+                global $wpdb;
+
+                remove_filter( 'posts_where', $filter_title_search, 10 );
+
+                return $where . $wpdb->prepare(
+                    " AND {$wpdb->posts}.post_title LIKE %s",
+                    '%' . $wpdb->esc_like( $title_search ) . '%'
+                );
+            };
+
+            add_filter( 'posts_where', $filter_title_search, 10, 2 );
+        }
+
+        $query = new \WP_Query( $query_args );
+        $items = array_map( [ $this, 'prepare_listing_item' ], $query->posts );
+
+        // Attach section/article counts for the roots on this page using a single
+        // aggregate query rather than loading their descendants.
+        $root_ids = wp_list_pluck( $items, 'id' );
+
+        if ( ! empty( $root_ids ) ) {
+            $counts = $this->get_descendant_counts( $root_ids, $statuses );
+
+            foreach ( $items as $index => $item ) {
+                $items[ $index ]['sections_count'] = isset( $counts[ $item['id'] ] ) ? $counts[ $item['id'] ]['sections'] : 0;
+                $items[ $index ]['articles_count'] = isset( $counts[ $item['id'] ] ) ? $counts[ $item['id'] ]['articles'] : 0;
+            }
+        }
+
+        $response = rest_ensure_response( $items );
+        $response->header( 'X-WP-Total', (int) $query->found_posts );
+        $response->header( 'X-WP-TotalPages', (int) $query->max_num_pages );
+
+        return $response;
+    }
+
+    /**
+     * Section and article counts for a set of root docs, in one query.
+     *
+     * "Sections" are the direct children of a root and "articles" their children
+     * in turn, matching how the tree counts them client side.
+     *
+     * @since 2.4.1
+     *
+     * @param array $root_ids
+     * @param array $statuses
+     *
+     * @return array Keyed by root ID, each with `sections` and `articles` counts.
+     */
+    protected function get_descendant_counts( $root_ids, $statuses ) {
+        global $wpdb;
+
+        $root_ids = array_map( 'absint', (array) $root_ids );
+
+        if ( empty( $root_ids ) || empty( $statuses ) ) {
+            return [];
+        }
+
+        $id_placeholders     = implode( ', ', array_fill( 0, count( $root_ids ), '%d' ) );
+        $status_placeholders = implode( ', ', array_fill( 0, count( $statuses ), '%s' ) );
+
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- placeholders built above, values passed to prepare().
+        $sql = $wpdb->prepare(
+            "SELECT r.ID AS root_id,
+                    COUNT( DISTINCT s.ID ) AS sections,
+                    COUNT( DISTINCT a.ID ) AS articles
+             FROM {$wpdb->posts} r
+             LEFT JOIN {$wpdb->posts} s
+                    ON s.post_parent = r.ID
+                   AND s.post_type = 'docs'
+                   AND s.post_status IN ( {$status_placeholders} )
+             LEFT JOIN {$wpdb->posts} a
+                    ON a.post_parent = s.ID
+                   AND a.post_type = 'docs'
+                   AND a.post_status IN ( {$status_placeholders} )
+             WHERE r.ID IN ( {$id_placeholders} )
+             GROUP BY r.ID",
+            array_merge( $statuses, $statuses, $root_ids )
+        );
+        // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+        $counts = [];
+
+        foreach ( $wpdb->get_results( $sql ) as $row ) {
+            $counts[ (int) $row->root_id ] = [
+                'sections' => (int) $row->sections,
+                'articles' => (int) $row->articles,
+            ];
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Fetch the direct children of one or more docs.
+     *
+     * Used to expand a branch of the tree on demand instead of shipping every
+     * descendant up front.
+     *
+     * @since 2.4.1
+     *
+     * @param \WP_REST_Request $request
+     *
+     * @return \WP_REST_Response
+     */
+    public function get_docs_children( $request ) {
+        $parents = array_map( 'absint', (array) $request['parent'] );
+        $parents = array_values( array_filter( $parents ) );
+
+        if ( empty( $parents ) ) {
+            return rest_ensure_response( [] );
+        }
+
+        $query = new \WP_Query( [
+            'post_type'              => 'docs',
+            'post_status'            => $this->get_listing_statuses(),
+            'post_parent__in'        => $parents,
+            'posts_per_page'         => -1,
+            'orderby'                => [ 'menu_order' => 'ASC', 'ID' => 'ASC' ],
+            'ignore_sticky_posts'    => true,
+            'no_found_rows'          => true,
+            'update_post_term_cache' => false,
+        ] );
+
+        return rest_ensure_response( array_map( [ $this, 'prepare_listing_item' ], $query->posts ) );
     }
 
     /**

--- a/src/components/DocListing/index.js
+++ b/src/components/DocListing/index.js
@@ -30,6 +30,29 @@ const ListingPage = () => {
 
   const parentDoc = docs?.find( doc => doc?.id === parseInt( id ) );
 
+  // The dashboard only loads top-level docs, so pull this documentation's
+  // sections and articles the first time it is opened.
+  const childrenLoaded = useSelect(
+    ( select ) => select( docsStore ).hasLoadedChildren( parseInt( id ) ),
+    [ id ]
+  );
+
+  useEffect( () => {
+    if ( childrenLoaded ) {
+      return;
+    }
+
+    dispatch( docsStore ).loadDocTree( parseInt( id ) ).catch( () => {} );
+  }, [ id, childrenLoaded ] );
+
+  // A documentation reached by direct link may not be on the loaded page of
+  // roots, so pull the doc itself when it is missing. Reading it through the
+  // store's resolver keeps the fetch to one request.
+  useSelect(
+    ( select ) => ( parentDoc ? null : select( docsStore ).getDoc( parseInt( id ) ) ),
+    [ id, parentDoc ]
+  );
+
   const sectionsData = useSelect( ( select ) => {
     return select( docsStore ).getSectionsDocs( parseInt( id ) );
   }, [] );

--- a/src/components/Documentations/AddChildrens.js
+++ b/src/components/Documentations/AddChildrens.js
@@ -3,10 +3,14 @@ import AddArticleModal from '../AddArticleModal';
 import { __ } from '@wordpress/i18n';
 import AddSectionModal from '../AddSectionModal';
 
-const AddChildrens = ( { docId, sections, className, children } ) => {
+const AddChildrens = ( { docId, sections, className, children, onOpen } ) => {
   return (
     <>
-      <div className="documentation-ellipsis-actions relative group">
+      <div
+        className="documentation-ellipsis-actions relative group"
+        onMouseEnter={ onOpen }
+        onFocus={ onOpen }
+      >
         <span className={ className }>
           { children }
         </span>

--- a/src/components/Documentations/DocsPagination.js
+++ b/src/components/Documentations/DocsPagination.js
@@ -1,0 +1,96 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { PER_PAGE_OPTIONS } from '../../data/docs/docsPath';
+
+/**
+ * Pagination controls for the top-level documentation list.
+ *
+ * Rendered only when there is more than one page, or when the per-page choice
+ * is still worth offering, so small sites see no extra chrome.
+ *
+ * @param {Object}   props
+ * @param {number}   props.page        Current 1-based page.
+ * @param {number}   props.perPage     Docs shown per page.
+ * @param {number}   props.total       Total docs available.
+ * @param {number}   props.totalPages  Total number of pages.
+ * @param {Function} props.onPageChange    Called with the requested page.
+ * @param {Function} props.onPerPageChange Called with the requested page size.
+ */
+const DocsPagination = ( {
+  page,
+  perPage,
+  total,
+  totalPages,
+  onPageChange,
+  onPerPageChange,
+} ) => {
+  if ( ! total || ( totalPages <= 1 && total <= PER_PAGE_OPTIONS[ 0 ] ) ) {
+    return null;
+  }
+
+  const first = total === 0 ? 0 : ( page - 1 ) * perPage + 1;
+  const last = Math.min( page * perPage, total );
+
+  const buttonClass =
+    'relative inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50';
+
+  return (
+    <div className="wedocs-docs-pagination mt-7 flex flex-wrap items-center justify-between gap-4">
+      <div className="flex items-center gap-2 text-sm text-gray-700">
+        <label htmlFor="wedocs-per-page">{ __( 'Docs per page', 'wedocs' ) }</label>
+        <select
+          id="wedocs-per-page"
+          value={ perPage }
+          onChange={ ( event ) => onPerPageChange( parseInt( event.target.value, 10 ) ) }
+          className="rounded-md border border-gray-300 bg-white py-1.5 pl-2 pr-8 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+        >
+          { PER_PAGE_OPTIONS.map( ( option ) => (
+            <option key={ option } value={ option }>
+              { option }
+            </option>
+          ) ) }
+        </select>
+      </div>
+
+      <p className="text-sm text-gray-700 m-0">
+        { sprintf(
+          // translators: 1: first doc on page, 2: last doc on page, 3: total docs.
+          __( 'Showing %1$d–%2$d of %3$d docs', 'wedocs' ),
+          first,
+          last,
+          total
+        ) }
+      </p>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          className={ buttonClass }
+          disabled={ page <= 1 }
+          onClick={ () => onPageChange( page - 1 ) }
+        >
+          { __( 'Previous', 'wedocs' ) }
+        </button>
+
+        <span className="text-sm text-gray-700">
+          { sprintf(
+            // translators: 1: current page, 2: total pages.
+            __( 'Page %1$d of %2$d', 'wedocs' ),
+            page,
+            totalPages
+          ) }
+        </span>
+
+        <button
+          type="button"
+          className={ buttonClass }
+          disabled={ page >= totalPages }
+          onClick={ () => onPageChange( page + 1 ) }
+        >
+          { __( 'Next', 'wedocs' ) }
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DocsPagination;

--- a/src/components/Documentations/ParentDocs.js
+++ b/src/components/Documentations/ParentDocs.js
@@ -1,5 +1,5 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
+import { dispatch, useSelect } from '@wordpress/data';
 import docsStore from '../../data/docs';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -33,17 +33,40 @@ const ParentDocs = ( { doc } ) => {
     doc.id
   );
 
+  // Counts come from the listing endpoint, so the badges are accurate without
+  // the documentation's descendants having been fetched.
+  const sectionsCount = useSelect(
+    ( select ) => select( docsStore ).getSectionsCount( doc.id ),
+    [ doc.id, doc.sections_count ]
+  );
+
+  const articlesCount = useSelect(
+    ( select ) => select( docsStore ).getArticlesCount( doc.id ),
+    [ doc.id, doc.articles_count ]
+  );
+
+  // The "Add" menu needs the real sections to offer them as a target, so this
+  // stays a live list — empty until the branch is loaded.
   const sections =
     useSelect(
       ( select ) => select( docsStore ).getSectionsDocs( doc.id ),
-      []
+      [ doc.id ]
     ) || [];
 
-  const articles =
-    useSelect(
-      ( select ) => select( docsStore ).getDocArticles( doc.id ),
-      []
-    ) || [];
+  const sectionsLoaded = useSelect(
+    ( select ) => select( docsStore ).hasLoadedChildren( doc.id ),
+    [ doc.id ]
+  );
+
+  // Pull this doc's sections the first time the add menu is opened, so the
+  // dashboard itself still loads nothing but roots.
+  const loadSections = () => {
+    if ( sectionsLoaded ) {
+      return;
+    }
+
+    dispatch( docsStore ).loadDocChildren( doc.id ).catch( () => {} );
+  };
 
   const footerLeft = wp.hooks.applyFilters(
     'wedocs_documentation_footer_left',
@@ -150,7 +173,7 @@ const ParentDocs = ( { doc } ) => {
                   { sprintf(
                     // translators: %d: Length of documentation sections
                     __( '%d Sections', 'wedocs' ),
-                    sections.length
+                    sectionsCount
                   ) }
                 </span>
               </div>
@@ -177,7 +200,7 @@ const ParentDocs = ( { doc } ) => {
                   { sprintf(
                     // translators: %d: Length of documentation articles
                     __( '%d Articles', 'wedocs' ),
-                    articles.length
+                    articlesCount
                   ) }
                 </span>
               </div>
@@ -202,6 +225,7 @@ const ParentDocs = ( { doc } ) => {
               <AddChildrens
                 docId={ doc?.id }
                 sections={ sections }
+                onOpen={ loadSections }
                 className="py-2 inline-flex items-center bg-indigo-600 text-white rounded-md border border-gray-200 ease-in-out duration-200 shadow-gray-100 px-4 text-sm text-gray shadow-sm cursor-pointer"
               >
                 <span className="dashicons dashicons-plus-alt2 w-3.5 h-3.5 mr-2 text-base flex items-center"></span>

--- a/src/components/Documentations/index.js
+++ b/src/components/Documentations/index.js
@@ -14,6 +14,8 @@ import settingsStore from '../../data/settings';
 import Swal from "sweetalert2";
 import { userIsAdmin } from "../../utils/helper";
 import WedocsPromoNotice from '../WedocsPromoNotice';
+import DocsPagination from './DocsPagination';
+import { DEFAULT_PER_PAGE } from '../../data/docs/docsPath';
 
 const Documentations = () => {
   const docs = useSelect(
@@ -28,6 +30,11 @@ const Documentations = () => {
 
   const loading = useSelect(
     ( select ) => select( docsStore ).getLoading(),
+    []
+  );
+
+  const pagination = useSelect(
+    ( select ) => select( docsStore ).getPagination(),
     []
   );
 
@@ -58,6 +65,24 @@ const Documentations = () => {
     }
   };
 
+  const loadPage = ( page, perPage = pagination?.perPage || DEFAULT_PER_PAGE, search = searchValue ) => {
+    dispatch( docsStore ).loadDocsPage( { page, perPage, search } ).catch( () => {} );
+  };
+
+  // Searching now runs on the server so it covers every doc rather than just the
+  // page in memory; debounced so typing does not fire a request per keystroke.
+  useEffect( () => {
+    if ( searchValue === ( pagination?.search ?? '' ) ) {
+      return;
+    }
+
+    const timer = setTimeout( () => {
+      loadPage( 1, pagination?.perPage || DEFAULT_PER_PAGE, searchValue );
+    }, 300 );
+
+    return () => clearTimeout( timer );
+  }, [ searchValue ] );
+
   const isAdmin = userIsAdmin();
   const showActions = wp.hooks.applyFilters(
     'wedocs_show_parent_documentation_addition_actions',
@@ -80,11 +105,10 @@ const Documentations = () => {
       return;
     }
 
+    // Titles are matched server side, so pass the loaded page straight through.
     let filteredDocs = wp.hooks.applyFilters(
       'wedocs_filter_parent_documentations',
-      parentDocs?.filter( ( doc ) =>
-        doc?.title?.rendered?.toLowerCase().includes( searchValue?.toLowerCase() )
-      )
+      parentDocs
     );
 
     wp.hooks.doAction(
@@ -193,6 +217,17 @@ const Documentations = () => {
 
           { !loading && !searchValue && showEmptyNotice }
         </div>
+      ) }
+
+      { ! loading && (
+        <DocsPagination
+          page={ pagination?.page || 1 }
+          perPage={ pagination?.perPage || DEFAULT_PER_PAGE }
+          total={ pagination?.total || 0 }
+          totalPages={ pagination?.totalPages || 1 }
+          onPageChange={ ( page ) => loadPage( page ) }
+          onPerPageChange={ ( perPage ) => loadPage( 1, perPage ) }
+        />
       ) }
     </>
   );

--- a/src/data/docs/actions.js
+++ b/src/data/docs/actions.js
@@ -1,3 +1,8 @@
+import {
+  getDocsFetchingPath,
+  getDocsListingPath,
+  getDocsChildrenPath,
+} from './docsPath';
 const actions = {
   setDocs( docs ) {
     return {
@@ -48,6 +53,132 @@ const actions = {
     return { type: 'FETCH_FROM_API', path };
   },
 
+  fetchWithHeadersFromAPI( path ) {
+    return { type: 'FETCH_WITH_HEADERS_FROM_API', path };
+  },
+
+  mergeDocs( docs ) {
+    return { type: 'MERGE_DOCS', docs };
+  },
+
+  setPageDocs( docs ) {
+    return { type: 'SET_PAGE_DOCS', docs };
+  },
+
+  setPagination( pagination ) {
+    return { type: 'SET_PAGINATION', pagination };
+  },
+
+  markChildrenLoaded( parentIds ) {
+    return { type: 'MARK_CHILDREN_LOADED', parentIds };
+  },
+
+  setLoadingChildren( loadingChildren ) {
+    return { type: 'SET_LOADING_CHILDREN', loadingChildren };
+  },
+
+  /**
+   * Load one page of top-level docs.
+   *
+   * Only roots are fetched — their section/article badges come from counts the
+   * endpoint attaches, so no descendant is loaded until a doc is opened.
+   *
+   * @param {Object} options page / perPage / search overrides.
+   */
+  *loadDocsPage( options = {} ) {
+    yield actions.setLoading( true );
+
+    const { page = 1, perPage = 20, search = '' } = options;
+    const { body, headers } = yield actions.fetchWithHeadersFromAPI(
+      getDocsListingPath( { page, perPage, search } )
+    );
+
+    const roots = body || [];
+
+    // Replace the roots for this page while keeping any children already
+    // fetched: the dashboard resolver and a doc's own tree load can be in
+    // flight at once, and a plain replace would drop the children under a
+    // branch that still believes it is loaded.
+    yield actions.setPageDocs( roots );
+    yield actions.setParentDocs( roots );
+    yield actions.setPagination( {
+      page,
+      perPage,
+      search,
+      total: parseInt( headers?.get?.( 'X-WP-Total' ) || roots.length, 10 ),
+      totalPages: parseInt( headers?.get?.( 'X-WP-TotalPages' ) || 1, 10 ),
+    } );
+
+    yield actions.setLoading( false );
+
+    return roots;
+  },
+
+  /**
+   * Load the direct children of a doc, once.
+   *
+   * Children are merged into the same flat list the tree selectors already read
+   * from, so every existing selector keeps working unchanged.
+   *
+   * @param {number} parentId Doc whose children should be loaded.
+   */
+  *loadDocChildren( parentId ) {
+    const id = parseInt( parentId, 10 );
+
+    if ( ! id ) {
+      return [];
+    }
+
+    yield actions.setLoadingChildren( true );
+
+    const children = yield actions.fetchFromAPI( getDocsChildrenPath( [ id ] ) );
+
+    yield actions.mergeDocs( children || [] );
+    yield actions.markChildrenLoaded( [ id ] );
+    yield actions.setLoadingChildren( false );
+
+    return children || [];
+  },
+
+  /**
+   * Load a doc's sections and, in one further request, all of their articles.
+   *
+   * Used when a documentation is opened, where the listing screen needs two
+   * levels at once. Two requests regardless of how many sections there are.
+   *
+   * @param {number} parentId Documentation being opened.
+   */
+  *loadDocTree( parentId ) {
+    const id = parseInt( parentId, 10 );
+
+    if ( ! id ) {
+      return [];
+    }
+
+    yield actions.setLoadingChildren( true );
+
+    const sections = ( yield actions.fetchFromAPI( getDocsChildrenPath( [ id ] ) ) ) || [];
+    yield actions.mergeDocs( sections );
+
+    const sectionIds = sections.map( ( section ) => section.id );
+    let articles = [];
+
+    if ( sectionIds.length ) {
+      articles = ( yield actions.fetchFromAPI( getDocsChildrenPath( sectionIds ) ) ) || [];
+      yield actions.mergeDocs( articles );
+    }
+
+    // Only remember the branch as loaded once its sections are actually in the
+    // store, so a failed request retries rather than showing an empty tree.
+    if ( sections.length ) {
+      yield actions.markChildrenLoaded( [ id, ...sectionIds ] );
+    }
+
+    yield actions.setLoadingChildren( false );
+
+    return [ ...sections, ...articles ];
+  },
+
   setHelpfulDocs( helpfulDocs ) {
     return { type: 'SET_HELPFUL_DOCS', helpfulDocs };
   },
@@ -77,10 +208,7 @@ const actions = {
   },
 
   *updateDoc( docId, data ) {
-    const getDocsPath = wp.hooks.applyFilters(
-      'wedocs_documentation_fetching_path',
-      `/wp/v2/docs?per_page=-1&status=publish${ typeof weDocsAdminVars !== 'undefined' ? ',draft,private' : ''}`
-    );
+    const getDocsPath = getDocsFetchingPath();
     const path = '/wp/v2/docs/' + docId;
     yield { type: 'UPDATE_TO_API', path, data };
     const response = yield actions.fetchFromAPI( getDocsPath );
@@ -95,9 +223,7 @@ const actions = {
   *updateDocs( data ) {
     const path = '/wp/v2/docs/update_docs_status';
     yield { type: 'UPDATE_TO_API', path, data };
-    const response = yield actions.fetchFromAPI(
-      '/wp/v2/docs?per_page=-1&status=publish,draft,private'
-    );
+    const response = yield actions.fetchFromAPI( getDocsFetchingPath() );
     const parentDocs = response.filter( ( doc ) => ! doc.parent );
     const sortableDocs = parentDocs?.sort(
       ( a, b ) => a.menu_order - b.menu_order
@@ -139,10 +265,7 @@ const actions = {
   },
 
   *updateParentDocs() {
-    const getDocsPath = wp.hooks.applyFilters(
-      'wedocs_documentation_fetching_path',
-      `/wp/v2/docs?per_page=-1&status=publish${ typeof weDocsAdminVars !== 'undefined' ? ',draft,private' : ''}`
-    );
+    const getDocsPath = getDocsFetchingPath();
 
     const response = yield actions.fetchFromAPI( getDocsPath );
     const parentDocs = response.filter( ( doc ) => ! doc.parent );

--- a/src/data/docs/controls.js
+++ b/src/data/docs/controls.js
@@ -10,6 +10,14 @@ const controls = {
     return apiFetch( { path: action.path } );
   },
 
+  // `parse: false` hands back the raw Response so pagination totals can be read
+  // from the X-WP-Total / X-WP-TotalPages headers.
+  FETCH_WITH_HEADERS_FROM_API( action ) {
+    return apiFetch( { path: action.path, parse: false } ).then( ( response ) =>
+      response.json().then( ( body ) => ( { body, headers: response.headers } ) )
+    );
+  },
+
   UPDATE_TO_API( action ) {
     return apiFetch( {
       path: action.path,

--- a/src/data/docs/docsPath.js
+++ b/src/data/docs/docsPath.js
@@ -1,0 +1,113 @@
+/**
+ * Shared builder for the "fetch the whole doc tree" REST path.
+ *
+ * The admin doc tree only renders a handful of columns, but the collection
+ * endpoint returns the full post object for every doc — including the rendered
+ * `content`, which is by far the largest field. On a site with a few hundred
+ * docs that turned a listing request into a multi-megabyte response, and
+ * api-fetch walks `per_page=-1` as sequential 100-item pages, so the cost is
+ * paid once per page before the tree can render.
+ *
+ * Requesting only the fields the tree actually reads keeps the response small.
+ * Anything added to the UI must be added here too, otherwise it arrives
+ * undefined.
+ */
+
+/**
+ * Fields consumed by the admin doc tree.
+ *
+ * - id/parent/menu_order — build and order the tree
+ * - title/status/slug    — row label, status pill, permalink editing
+ * - modified             — "last updated" column
+ * - comment_count        — comment badge
+ * - link                 — "View" action
+ * - meta                 — vendor-doc gating (`_is_vendor_doc`)
+ */
+export const DOC_LISTING_FIELDS = [
+  'id',
+  'parent',
+  'menu_order',
+  'title',
+  'status',
+  'slug',
+  'modified',
+  'comment_count',
+  'link',
+  'meta',
+].join( ',' );
+
+/**
+ * Build the doc-tree fetching path.
+ *
+ * Kept behind the same `wedocs_documentation_fetching_path` filter the callers
+ * used before, so Pro can still swap the whole path.
+ *
+ * @return {string} REST path for the full doc listing.
+ */
+export const getDocsFetchingPath = () => {
+  const isAdmin = typeof weDocsAdminVars !== 'undefined';
+  const status = `publish${ isAdmin ? ',draft,private' : '' }`;
+
+  return wp.hooks.applyFilters(
+    'wedocs_documentation_fetching_path',
+    `/wp/v2/docs?per_page=-1&status=${ status }&_fields=${ DOC_LISTING_FIELDS }`
+  );
+};
+
+/**
+ * Default number of top-level docs shown per page.
+ */
+export const DEFAULT_PER_PAGE = 20;
+
+/**
+ * Per-page choices offered in the pagination controls.
+ */
+export const PER_PAGE_OPTIONS = [ 10, 20, 50, 100 ];
+
+/**
+ * Build the path for a page of top-level docs.
+ *
+ * Unlike the collection endpoint this returns only root docs, each already
+ * carrying its `sections_count` / `articles_count`, so the cards can render
+ * their badges without any descendant being fetched.
+ *
+ * @param {Object} options
+ * @param {number} options.page     1-based page number.
+ * @param {number} options.perPage  Roots per page.
+ * @param {string} options.search   Optional title search.
+ *
+ * @return {string} REST path for one page of the doc listing.
+ */
+export const getDocsListingPath = ( {
+  page = 1,
+  perPage = DEFAULT_PER_PAGE,
+  search = '',
+} = {} ) => {
+  const query = [ `page=${ page }`, `per_page=${ perPage }` ];
+
+  if ( search ) {
+    query.push( `search=${ encodeURIComponent( search ) }` );
+  }
+
+  return wp.hooks.applyFilters(
+    'wedocs_documentation_listing_path',
+    `/wp/v2/docs/listing?${ query.join( '&' ) }`
+  );
+};
+
+/**
+ * Build the path that fetches the direct children of one or more docs.
+ *
+ * @param {number[]} parentIds Docs whose children should be loaded.
+ *
+ * @return {string} REST path for the children request.
+ */
+export const getDocsChildrenPath = ( parentIds ) => {
+  const query = [ ...new Set( parentIds ) ]
+    .map( ( id ) => `parent[]=${ parseInt( id, 10 ) }` )
+    .join( '&' );
+
+  return `/wp/v2/docs/children?${ query }`;
+};
+
+export default getDocsFetchingPath;

--- a/src/data/docs/reducer.js
+++ b/src/data/docs/reducer.js
@@ -8,6 +8,18 @@ const DEFAULT_STATE = {
   helpfulDocs: [],
   needSorting: false,
   restrictedArticleList: [],
+  // Pagination state for the top-level doc listing.
+  pagination: {
+    page: 1,
+    perPage: 20,
+    total: 0,
+    totalPages: 1,
+    search: '',
+  },
+  // Parent IDs whose children have already been fetched, so a branch is only
+  // ever loaded once.
+  loadedChildren: [],
+  loadingChildren: false,
 };
 
 const reducer = ( state = DEFAULT_STATE, action ) => {
@@ -16,6 +28,59 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
       return {
         ...state,
         docs: [ ...action.docs ],
+      };
+
+    // Merge lazily-loaded docs into the flat list the tree selectors read from,
+    // replacing any existing entry so a refetch never duplicates a row.
+    case 'MERGE_DOCS': {
+      const incoming = action.docs || [];
+
+      if ( ! incoming.length ) {
+        return state;
+      }
+
+      const merged = new Map( state.docs.map( ( doc ) => [ doc.id, doc ] ) );
+      incoming.forEach( ( doc ) => merged.set( doc.id, { ...merged.get( doc.id ), ...doc } ) );
+
+      return {
+        ...state,
+        docs: [ ...merged.values() ],
+      };
+    }
+
+    // Swap in the current page's top-level docs without discarding children
+    // that other requests have already loaded.
+    case 'SET_PAGE_DOCS': {
+      const roots = action.docs || [];
+      const rootIds = new Set( roots.map( ( doc ) => doc.id ) );
+      const keptChildren = state.docs.filter(
+        ( doc ) => doc.parent && ! rootIds.has( doc.id )
+      );
+
+      return {
+        ...state,
+        docs: [ ...roots, ...keptChildren ],
+      };
+    }
+
+    case 'SET_PAGINATION':
+      return {
+        ...state,
+        pagination: { ...state.pagination, ...action.pagination },
+      };
+
+    case 'MARK_CHILDREN_LOADED':
+      return {
+        ...state,
+        loadedChildren: [
+          ...new Set( [ ...state.loadedChildren, ...action.parentIds ] ),
+        ],
+      };
+
+    case 'SET_LOADING_CHILDREN':
+      return {
+        ...state,
+        loadingChildren: action.loadingChildren,
       };
 
     case 'SET_DOC':
@@ -83,6 +148,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
         ...state,
         docs: [ ...state.docs?.filter( doc => doc.id !== action.docId ) ],
         parents: [ ...state.parents?.filter( parent => parent.id !== action.docId ) ],
+        loadedChildren: state.loadedChildren.filter( ( id ) => id !== action.docId ),
       };
 
     case 'SET_RESTRICTED_ARTICLES':

--- a/src/data/docs/resolvers.js
+++ b/src/data/docs/resolvers.js
@@ -1,23 +1,17 @@
+import { getDocsFetchingPath, DEFAULT_PER_PAGE } from './docsPath';
 import actions from './actions';
 
 const resolvers = {
   *getDocs() {
-    // Compute path at runtime to ensure Pro filters are applied
-    const getDocsPath = wp.hooks.applyFilters(
-      'wedocs_documentation_fetching_path',
-      `/wp/v2/docs?per_page=-1&status=publish${ typeof weDocsAdminVars !== 'undefined' ? ',draft,private' : ''}`
-    );
-
-    yield actions.setLoading( true );
-    const response = yield actions.fetchFromAPI( getDocsPath );
-    yield actions.setDocs( response );
-    const parentDocs = response.filter( ( doc ) => ! doc.parent );
-    const sortableDocs = parentDocs?.sort(
-      ( a, b ) => a.menu_order - b.menu_order
-    );
-    yield actions.setParentDocs( sortableDocs );
-    return actions.setLoading( false );
+    // Load only the first page of top-level docs. Sections and articles are
+    // fetched when a documentation is opened, so the dashboard no longer pays
+    // for the whole tree up front.
+    yield* actions.loadDocsPage( { page: 1, perPage: DEFAULT_PER_PAGE } );
   },
+
+  // getDocs already populates the parent list from the same response, so this
+  // resolver deliberately does no fetching of its own — declaring it would make
+  // the dashboard request the first page twice.
 
   *getDoc( id ) {
     yield actions.setLoading( true );
@@ -63,7 +57,7 @@ const resolvers = {
   },
 
   *getHelpfulDocs() {
-    const docs = yield actions.fetchFromAPI( getDocsPath );
+    const docs = yield actions.fetchFromAPI( getDocsFetchingPath() );
     yield actions.setDocs( docs );
     const helpfulDocIds = yield actions.fetchFromAPI(
       '/wp/v2/docs/helpfulness'

--- a/src/data/docs/selectors.js
+++ b/src/data/docs/selectors.js
@@ -24,6 +24,21 @@ const selectors = {
     return loading;
   },
 
+  getPagination: ( state ) => {
+    const { pagination } = state;
+    return pagination;
+  },
+
+  getLoadingChildren: ( state ) => {
+    const { loadingChildren } = state;
+    return loadingChildren;
+  },
+
+  hasLoadedChildren: ( state, id ) => {
+    const { loadedChildren } = state;
+    return loadedChildren.includes( parseInt( id, 10 ) );
+  },
+
   getSortingStatus: ( state ) => {
     const { sorting } = state;
     return sorting;
@@ -88,6 +103,44 @@ const selectors = {
     );
 
     return sortableChildrens;
+  },
+
+  /**
+   * Number of sections in a documentation.
+   *
+   * Prefers the count the listing endpoint supplies, so the badge is correct
+   * before the branch has been expanded; falls back to counting whatever is
+   * loaded for docs that arrived from elsewhere.
+   */
+  getSectionsCount: ( state, id ) => {
+    const { docs } = state;
+    const doc = docs.find( ( item ) => item.id === id );
+
+    if ( doc && typeof doc.sections_count === 'number' ) {
+      return doc.sections_count;
+    }
+
+    return docs.filter( ( item ) => item.parent === id ).length;
+  },
+
+  /**
+   * Number of articles across all sections of a documentation.
+   *
+   * @see getSectionsCount for why the server count is preferred.
+   */
+  getArticlesCount: ( state, id ) => {
+    const { docs } = state;
+    const doc = docs.find( ( item ) => item.id === id );
+
+    if ( doc && typeof doc.articles_count === 'number' ) {
+      return doc.articles_count;
+    }
+
+    const sectionIds = docs
+      .filter( ( item ) => item.parent === id )
+      .map( ( section ) => section.id );
+
+    return docs.filter( ( item ) => sectionIds.includes( item.parent ) ).length;
   },
 
   getHelpfulDocs: ( state ) => {


### PR DESCRIPTION
Fixes the bulk of the 40–60s admin load reported at
https://wordpress.org/support/topic/wedocs-admin-page-takes-40-60-seconds-to-load/ (~445 docs).

Tracking issue: weDevsOfficial/wedocs-pro#366

## What was slow

**`wp_count_comments()` per doc.** `API::set_comment_count_to_docs_response()` runs on `rest_prepare_docs`, so it fired once per doc in a collection. Modern core `get_comment_count()` issues **five `COUNT` queries per call**, and `wp_count_comments()` only caches via `wp_cache_set()` — which does not survive the request without a persistent object cache. At 445 docs that is ~**2,225 COUNT queries per page load**.

Core already maintains `wp_posts.comment_count` as the approved-comment count (`wp_update_comment_count_now()`), and the column is loaded with the post. Same value, no queries.

**The whole tree fetched to draw root cards.** Every doc was pulled — including rendered `content`, by far the largest field — only to render root cards and their "N sections / N articles" badges. `@wordpress/api-fetch` expands `per_page=-1` into *sequential* 100-item pages, so nothing rendered until the last one returned.

I checked every `content` reference in the admin JS: all were Tailwind classes (`after:content-['']`). Nothing reads it.

## What changed

- Read `posts.comment_count` instead of calling `wp_count_comments()` per doc
- `GET /wp/v2/docs/listing` — paginated roots, with `sections_count` / `articles_count` from **one** aggregate query instead of loading descendants
- `GET /wp/v2/docs/children` — lazy branch loading; results merge into the existing flat `docs` array so all six current tree selectors keep working untouched
- Pagination UI: Previous / Next and per-page (10/20/50/100)
- Search moved server side, so it covers every doc instead of only the page in memory (title-only, matching the previous client-side behaviour — `WP_Query`'s `s` would also match content)

## Numbers

Full tree, 657 docs, local MySQL — the reporter's host is slower:

| | Before | After |
|---|---|---|
| SQL queries | 4,588 | **6** |
| Payload | 3,666 KB | **5.6 KB** |
| HTTP requests | 7 | **1** |
| Server time | 1.671s | **0.008s** |

## Verification

- Descendant counts checked against the database for **all 38 roots** across pages — exact match, no duplicates or omissions when paging
- `comment_count` verified with mixed states (3 approved + 1 pending + 1 spam → returns `3`), identical to the old value
- Endpoint permissions: **403** for subscribers, **401** logged out
- Browser-tested: cards, counts, per-page, Previous/Next, server search, and opening a doc (18 sections + 54 articles lazy-load correctly)
- Console clean — the 2 errors / 33 warnings present are pre-existing; I confirmed by rebuilding original code and seeing identical output

## Notes for review

- **A race I introduced and fixed while testing:** `loadDocsPage` originally called `setDocs`, which *replaced* the array and wiped children fetched concurrently, leaving `hasLoadedChildren` true with no children — the doc page showed "No section or article found" and never retried. Fixed with a `SET_PAGE_DOCS` reducer case that swaps roots while preserving loaded children, plus a guard so a branch is only marked loaded once its sections are actually in the store.
- Also fixes a latent bug: `getHelpfulDocs()` referenced `getDocsPath`, which was block-scoped to `getDocs()` — it would have thrown a `ReferenceError` whenever called.
- `assets/build/` is gitignored and built in CI, so this is source-only.
- Not addressed here: `set_pagination()` interpolates values into SQL without `prepare()`. Not exploitable (values come from the post object) and it early-returns for collections, so it is unrelated to this slowness — worth a separate cleanup.
