### PR TITLE
fix: show the loading placeholder while a doc's tree is fetched

### DIFF
--- a/src/components/DocListing/index.js
+++ b/src/components/DocListing/index.js
@@ -37,13 +37,21 @@ const ListingPage = () => {
     [ id ]
   );
 
+  const [ treeRequested, setTreeRequested ] = useState( null );
+
   useEffect( () => {
-    if ( childrenLoaded ) {
+    const docId = parseInt( id );
+
+    // Guard on the requested ID rather than the loaded flag alone: a failed
+    // request leaves the branch unmarked, and re-running on every render would
+    // turn that into a request loop.
+    if ( childrenLoaded || treeRequested === docId ) {
       return;
     }
 
-    dispatch( docsStore ).loadDocTree( parseInt( id ) ).catch( () => {} );
-  }, [ id, childrenLoaded ] );
+    setTreeRequested( docId );
+    dispatch( docsStore ).loadDocTree( docId ).catch( () => {} );
+  }, [ id, childrenLoaded, treeRequested ] );
 
   // A documentation reached by direct link may not be on the loaded page of
   // roots, so pull the doc itself when it is missing. Reading it through the
@@ -55,12 +63,22 @@ const ListingPage = () => {
 
   const sectionsData = useSelect( ( select ) => {
     return select( docsStore ).getSectionsDocs( parseInt( id ) );
-  }, [] );
+  }, [ id, docs ] );
 
-  const loading = useSelect(
+  const docsLoading = useSelect(
     ( select ) => select( docsStore ).getLoading(),
     []
   );
+
+  const loadingChildren = useSelect(
+    ( select ) => select( docsStore ).getLoadingChildren(),
+    []
+  );
+
+  // This screen is only ready once the documentation's own branch has been
+  // fetched. Without this it rendered its empty state for the whole of that
+  // request, because the store's `loading` flag belongs to the dashboard.
+  const loading = docsLoading || loadingChildren || ! childrenLoaded;
 
   const sortableStatus = useSelect(
     ( select ) => select( docsStore ).getSortingStatus(),
@@ -85,7 +103,7 @@ const ListingPage = () => {
 
   const docArticles = useSelect(
     ( select ) => select( docsStore ).getDocArticles( parseInt( id ) ),
-    []
+    [ id, docs ]
   );
 
   const filteredArticles = docArticles?.filter( ( article ) => {

--- a/src/data/docs/actions.js
+++ b/src/data/docs/actions.js
@@ -157,24 +157,27 @@ const actions = {
 
     yield actions.setLoadingChildren( true );
 
-    const sections = ( yield actions.fetchFromAPI( getDocsChildrenPath( [ id ] ) ) ) || [];
-    yield actions.mergeDocs( sections );
-
-    const sectionIds = sections.map( ( section ) => section.id );
+    let sections = [];
     let articles = [];
 
-    if ( sectionIds.length ) {
-      articles = ( yield actions.fetchFromAPI( getDocsChildrenPath( sectionIds ) ) ) || [];
-      yield actions.mergeDocs( articles );
-    }
+    try {
+      sections = ( yield actions.fetchFromAPI( getDocsChildrenPath( [ id ] ) ) ) || [];
+      yield actions.mergeDocs( sections );
 
-    // Only remember the branch as loaded once its sections are actually in the
-    // store, so a failed request retries rather than showing an empty tree.
-    if ( sections.length ) {
+      const sectionIds = sections.map( ( section ) => section.id );
+
+      if ( sectionIds.length ) {
+        articles = ( yield actions.fetchFromAPI( getDocsChildrenPath( sectionIds ) ) ) || [];
+        yield actions.mergeDocs( articles );
+      }
+
+      // Marked only on success, so a documentation that genuinely has no
+      // sections still counts as loaded and stops the screen waiting, while a
+      // failed request is left unmarked and retried.
       yield actions.markChildrenLoaded( [ id, ...sectionIds ] );
+    } finally {
+      yield actions.setLoadingChildren( false );
     }
-
-    yield actions.setLoadingChildren( false );
 
     return [ ...sections, ...articles ];
   },


### PR DESCRIPTION
Follow-up to #340 (already merged). Fixes a UX regression that came in with the lazy loading.

Tracking issue: weDevsOfficial/wedocs-pro#366

## Symptom

Opening a documentation showed a **blank screen** first, then everything appeared at once with no transition — no skeleton, no animation.

## Why

Three things, all introduced or exposed by the lazy loading in #340.

**1. The placeholder was gated on the wrong flag.** `DocListing` used the store's `loading`, which tracks the *dashboard's* request. During a doc's own child fetch that flag is `false`, so `! loading` was true and the component rendered its "No section or article found" branch for the entire request.

**2. The selectors were not subscribed.** `getSectionsDocs` and `getDocArticles` were called with an empty dependency list:

```js
}, [] );
```

so they kept returning the value captured on first render and only refreshed when something unrelated forced a re-render. That is what made content arrive late rather than as soon as the fetch resolved.

**3. A doc with no sections would wait forever.** `loadDocTree` only called `markChildrenLoaded` when `sections.length` was truthy — a guard I added in #340 to make failed requests retry. But that conflates "request failed" with "this doc genuinely has no sections", so an empty documentation never became `childrenLoaded`.

## Changes

- Derive this screen's readiness from its own state: `docsLoading || loadingChildren || ! childrenLoaded`
- Give the section/article selectors real dependencies (`[ id, docs ]`) so they track the store
- Mark a branch loaded whenever the request **succeeds**, empty or not, in a `try/finally` so `loadingChildren` always clears; a genuine failure stays unmarked and retries
- Track the requested ID in the effect, so an unmarked branch after a failure cannot become a request loop

## Verification

Loading gate checked across every transition:

| State | `loading` | Renders |
|---|---|---|
| Mount, nothing started | `true` | Skeleton |
| Child fetch in flight | `true` | Skeleton |
| Loaded, has sections | `false` | Content |
| Loaded, **no** sections | `false` | Empty state (not a spinner) |
| Dashboard still loading | `true` | Skeleton |
| Revisit cached branch | `false` | Content immediately |

Confirmed against the live API that the empty case returns HTTP 200 with 0 sections, so it now marks loaded and shows its empty state rather than waiting forever.

Build and `no-undef` lint clean.

**Not yet visually confirmed in a browser** — the Playwright profile was locked by a running Chrome instance while I was working, so the skeleton itself has not been seen on screen. The state logic is verified as above, but a quick manual check of the skeleton appearing on a slow doc would be worth doing before merge.
