### PR TITLE
chore: bump version to 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weDocs",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "A documentation plugin for WordPress",
   "author": "Tareq Hasan",
   "license": "GPL",

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: docs, documentation, knowledge base, wiki, ai-powered knowledgebase
 Requires at least: 5.6
 Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 2.4.1
+Stable tag: 2.5.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -229,6 +229,11 @@ Yes. The free version includes a dashboard showing total docs, articles, total v
 ---
 
 ## Changelog
+
+**v2.5.0 (27 Aug, 2026)**
+- **Added:** FAQ section for your documentation site. Create FAQ groups, write questions and answers in a rich text editor, drag to reorder them, switch a group on or off, and publish them as an expandable accordion on any page with the `[wedocs_faq]` shortcode.
+- **Added:** Shortcodes tab in Settings listing every weDocs shortcode with its attributes, defaults and an example you can copy in one click, so you no longer have to look them up.
+- **Improved:** Documentation Dashboard cards now follow the weDocs colour palette, and the admin menu uses the weDocs mark in place of a generic icon.
 
 **v2.4.1 (20 Aug, 2026)**
 - **Update:** Tested up to WordPress 7.1.

--- a/wedocs.php
+++ b/wedocs.php
@@ -3,7 +3,7 @@
 Plugin Name: weDocs
 Plugin URI: https://wedocs.co/
 Description: A documentation plugin for WordPress
-Version: 2.4.1
+Version: 2.5.0
 Author: weDevs
 Author URI: https://wedocs.co/?utm_source=wporg&utm_medium=banner&utm_campaign=author-uri
 License: GPL2
@@ -60,7 +60,7 @@ final class WeDocs {
      *
      * @var string
      */
-    const VERSION = '2.4.1';
+    const VERSION = '2.5.0';
 
     /**
      * The plugin url.


### PR DESCRIPTION
Release prep for **weDocs 2.5.0**. Version bump plus the changelog entry; no functional change.

## Version fields

All four the deploy workflow checks are synced to `2.5.0` (it hard-aborts on a mismatch, and wp.org rejects a `Stable tag` that disagrees with the header):

| Field | Value |
|---|---|
| `wedocs.php` `Version:` | 2.5.0 |
| `wedocs.php` `const VERSION` | 2.5.0 |
| `package.json` `version` | 2.5.0 |
| `readme.txt` `Stable tag` | 2.5.0 |

## Changelog

```
**v2.5.0 (27 Aug, 2026)**
- **Added:** FAQ section for your documentation site. Create FAQ groups, write
  questions and answers in a rich text editor, drag to reorder them, switch a
  group on or off, and publish them as an expandable accordion on any page with
  the [wedocs_faq] shortcode.
- **Added:** Shortcodes tab in Settings listing every weDocs shortcode with its
  attributes, defaults and an example you can copy in one click, so you no
  longer have to look them up.
- **Improved:** Documentation Dashboard cards now follow the weDocs colour
  palette, and the admin menu uses the weDocs mark in place of a generic icon.
```

## What is deliberately not in the changelog

Site owners are the audience, so developer-facing work is left out:

- The Playwright e2e suites and the CI workflow (#344).
- The `fast-uri` bump from #341. It is an npm `overrides` on a build-time transitive dependency, so it never reaches the shipped package.
- The FAQ and Shortcodes bug fixes made during development. Both features are **new in this release**, so those were fixes to unreleased code; listing them would describe bugs no user ever saw.
- Internal refactors, and the loading-placeholder change that was reverted in the same range and nets to nothing.

## Pre-release checks

Ran the release skill's mandatory block against this tree:

- `assets/build` untracked ✓ (CI builds and ships it; a guard workflow fails anything that tracks it)
- `register_blocks()` intact, 19 block entries ✓
- block-styles `require` present ✓
- no real `BUILD_DIR` key in `deploy-org.yml` ✓ — the only match is the comment warning against reintroducing it
- `tailwind.config.js` still the clean ESM import form ✓
- no diff to `wedocs.php` or `tailwind.config.js` since `v2.4.1` ✓

One note for whoever releases next: `git ls-remote --tags | sort -V | tail -1` reports **`v2.11.12`**, which is a stray tag from 24 Jul 2025 pointing at an unrelated develop merge. The real previous release is `v2.4.1`, which is what wp.org serves. The skill's `LAST` detection picks the stray one, so its baseline diff needs the real tag passed by hand.

Tag `v2.5.0` goes on `develop` once this merges and CI is green.