### PR TITLE
ci: pin the CI Node version to .nvmrc

### DIFF
--- a/.github/workflows/deploy-org.yml
+++ b/.github/workflows/deploy-org.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
 
-      - name: Use Node.js 24
+      - name: Use Node.js (version from .nvmrc)
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
 
       - name: Use desired version of PHP

--- a/.github/workflows/e2e-wedocs.yml
+++ b/.github/workflows/e2e-wedocs.yml
@@ -50,10 +50,10 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
 
-      - name: Use Node.js 24
+      - name: Use Node.js (version from .nvmrc)
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version-file: '.nvmrc'
 
       # wedocs.php requires vendor/autoload.php outright, so without composer the
       # plugin fatals on load and wp-env start exits 255 before a spec ever runs.
@@ -126,7 +126,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version-file: '.nvmrc'
       - name: Install e2e dependencies
         working-directory: tests/e2e-playwright
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Every workflow hardcoded `node-version: 24` while `.nvmrc` pins `24.20.0` — two sources of truth for the same thing.

That is exactly the drift the Node 24 work set out to end. Before it, this repo disagreed with itself three ways: `.nvmrc` said 18, the e2e workflow said 22, the deploy workflow said 18.

## Change

`node-version-file: '.nvmrc'` in all three `setup-node` steps (`deploy-org.yml`, and both jobs in `e2e-wedocs.yml`). Bumping Node is now a one-line change in one file, and CI cannot silently disagree with local builds.

Step names lost their hardcoded version too, for the same reason — `Use Node.js (version from .nvmrc)`.

pnpm was already immune to this: `pnpm/action-setup@v6` reads the version from `packageManager` in `package.json`.

## Verified

- All four workflow files still parse as valid YAML
- Full Playwright suite green on the fork through the changed steps, so `setup-node` resolves `.nvmrc` correctly
- `assets/build` confirmed untracked and gitignored, so the build-untracked guard passes