### PR TITLE
fix: restore the admin spacing Tailwind 4 broke

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -92,9 +92,78 @@ const scopedRootMatch = () => ( {
 } );
 scopedRootMatch.postcss = true;
 
+/**
+ * PostCSS plugin: unwrap the `:where()` Tailwind 4 puts around `space-x-*`,
+ * `space-y-*` and `divide-*`.
+ *
+ * Those utilities style a SIBLING of the element the class sits on, so Tailwind
+ * 4 wraps the whole selector in `:where()` to drop it to zero specificity and
+ * keep it easy to override:
+ *
+ *   :where(.wedocs-document .space-y-6 > :not(:last-child)) { … }
+ *
+ * That only holds up because Tailwind 4 puts preflight in `@layer base`, and a
+ * layer loses to everything unlayered whatever its specificity. wp-admin is
+ * unlayered and styles bare elements (`p, .wp-die-message { margin: 1em 0 }`,
+ * `h1`-`h6`), so at zero specificity `space-y-*` loses to wp-admin on any `p`
+ * or heading child - and to the preflight parity reset in
+ * `src/assets/css/index.css`, which has to sit at (0,0,1) to beat wp-admin at
+ * all.
+ *
+ * Tailwind 3 emitted these unwrapped, at the same (0,2,0) as every other scoped
+ * utility, so they outranked both. Restoring that shape puts the cascade back:
+ * wp-admin element rules < the preflight reset < utilities.
+ *
+ * Only a selector that is ENTIRELY one `:where()` around a compound with a
+ * combinator is unwrapped, which is exactly the shape these utilities take.
+ * The reset in `index.css` reads `:where(.wedocs-document, …):is(p, …)`, whose
+ * `:where()` closes early, so it is left alone - as is every `:where()`
+ * Tailwind and daisyUI use inside a larger selector.
+ */
+const unwrapScopedWhere = () => ( {
+    postcssPlugin: 'wedocs-unwrap-scoped-where',
+    Rule( rule ) {
+        const parts = splitSelectors( rule.selector ).map( ( part ) => {
+            if ( ! part.startsWith( ':where(' ) || ! part.endsWith( ')' ) ) {
+                return part;
+            }
+
+            // Only unwrap when the opening `:where(` is what the trailing `)`
+            // closes, so a selector that merely starts with one is untouched.
+            let depth = 0;
+
+            for ( let i = ':where('.length - 1; i < part.length; i++ ) {
+                if ( part[ i ] === '(' ) {
+                    depth++;
+                } else if ( part[ i ] === ')' ) {
+                    depth--;
+
+                    if ( depth === 0 && i !== part.length - 1 ) {
+                        return part;
+                    }
+                }
+            }
+
+            const inner = part.slice( ':where('.length, -1 );
+
+            // These utilities always reach a sibling, so the wrapped selector
+            // carries a combinator. A `:where()` holding a plain selector list
+            // is somebody else's, and keeps the specificity it was given.
+            return splitSelectors( inner ).length === 1 &&
+                /[\s>+~]/.test( inner )
+                ? inner
+                : part;
+        } );
+
+        rule.selector = parts.join( ',' );
+    },
+} );
+unwrapScopedWhere.postcss = true;
+
 module.exports = {
     plugins: [
         require( '@tailwindcss/postcss' ),
         scopedRootMatch,
+        unwrapScopedWhere,
     ]
 }

--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -9,6 +9,25 @@
   selector: .wedocs-document;
 }
 
+/* Tailwind 4 dropped preflight's element-level margin reset and folded it into
+   the universal `*` rule, which carries no specificity at all. wp-admin styles
+   bare elements (`p, .wp-die-message { margin: 1em 0 }`,
+   `h2, h3 { margin: 1em 0 }`), so those margins beat it and came back inside
+   our container, padding out every card and card header.
+
+   This restores the element list Tailwind 3's preflight reset, at the same
+   specificity wp-admin uses, scoped exactly as the plugin above scopes the rest
+   of preflight. `:where()` keeps the scope free, so the rule stays at (0,0,1):
+   enough to tie wp-admin and win on load order, and still below every utility
+   class, so `mt-*` and friends keep overriding it. */
+:where(.wedocs-document, .wedocs-document *):is(
+  blockquote, dd, dl, fieldset, figure, h1, h2, h3, h4, h5, h6, hr, legend,
+  menu, ol, p, pre, ul
+) {
+  margin: 0;
+  padding: 0;
+}
+
 /* daisyUI 5 replaces v2's `base: false`. Three things matter here:
    - `root` scopes the theme custom properties to our container instead of
      `:root`, so the colour variables never touch the rest of wp-admin.

--- a/src/components/ProPreviews/index.js
+++ b/src/components/ProPreviews/index.js
@@ -225,8 +225,10 @@ wp.hooks.addFilter(
                         strokeLinejoin="round"
                         className="-ml-1 mr-4 pro-settings"
                     >
-                        <path d="M12 2a4 4 0 0 1 4 4v5a4 4 0 0 1-8 0V6a4 4 0 0 1 4-4z" />
-                        <path d="M5 10v1a7 7 0 0 0 14 0v-1M12 18v4" />
+                        <path d="M12 22v-5" />
+                        <path d="M9 8V2" />
+                        <path d="M15 8V2" />
+                        <path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8z" />
                     </svg>
                 ),
             };


### PR DESCRIPTION
Fixes the spacing the Tailwind 4 upgrade took out of the admin UI: cards and card headers padded out, gaps between dashboard sections collapsed.

Closes weDevsOfficial/wedocs-pro#404

## Cause

Two Tailwind 4 changes that only misbehave together with wp-admin's stylesheet.

**Preflight's margin reset moved onto `*`**, which has zero specificity. `wp-admin/css/common.css` is unlayered and styles bare elements at (0,0,1):

```css
p, .wp-die-message { font-size: 13px; line-height: 1.5; margin: 1em 0 }
h2, h3 { color: #1d2327; font-size: 1.3em; margin: 1em 0 }
```

So wp-admin wins and its margins come back inside `.wedocs-document`. That is the fat cards and headers. Tailwind 3 reset margins on a named element list, tying wp-admin and winning on load order.

**`space-x-*`, `space-y-*` and `divide-*` are wrapped in `:where()`**, also zero specificity:

```css
:where(.wedocs-document .space-y-6 > :not(:last-child)) { … }
```

They only survive in stock Tailwind because preflight sits in `@layer base`, and a cascade layer loses to anything unlayered whatever its selector. Against wp-admin they lose on any paragraph or heading child. That is the missing section gaps.

## Fix

Both changes restore what Tailwind 3 emitted. `@layer base` is left intact, so `@tailwindcss/forms` and daisyUI keep the order they expect.

- `src/assets/css/index.css` restores preflight's element-level margin reset at (0,0,1), scoped `:where(.wedocs-document, .wedocs-document *)` so it beats wp-admin and still loses to every utility.
- `postcss.config.js` unwraps the `:where()` around the space and divide utilities, back to (0,2,0).

Ladder: wp-admin element rules < preflight reset < utilities.

Unlayering `@layer base` looks like the obvious fix and is not one. It puts `*{margin:0}` after `space-y-*` at equal specificity, so it wins ties and every section gap goes to zero. Tried it, measured it, backed it out.

## Measured

Against the real `common.css` and `forms.css`, before and after:

| | before | after |
|---|---|---|
| Dashboard stat card | 170px | 114px |
| Card header | 96px | 60px |
| Gap, `<h1>` → stat cards | 0px | 24px |
| Gap, cards → panel row | 24px | 24px |
| `divide-y` border | 1px | 1px |
| `space-y-1.5` on a heading | 20px | 6px |

The heading gap was already broken before this branch and is now correct.

Collateral sweep over utilities, daisyUI `.btn`, form inputs, lists, images, table cells and the toggle: three changes, all corrections. A list gets its `space-y-3` back, and bare headings lose wp-admin's margins. Link colours, input styling, daisyUI components and heading fonts are untouched.

## Also here

The MCP settings menu icon was a microphone, which reads as voice input. Replaced with a plug, matching the panel's own language: connector URL, connected apps. The matching change to the real Pro screen is in weDevsOfficial/wedocs-pro#405 so the preview and the real thing stay identical.
