### PR TITLE
chore: declare the PHP requirement in the plugin header

### DIFF
--- a/wedocs.php
+++ b/wedocs.php
@@ -9,6 +9,7 @@ Author URI: https://wedocs.co/?utm_source=wporg&utm_medium=banner&utm_campaign=a
 License: GPL2
 Text Domain: wedocs
 Domain Path: /languages
+Requires PHP: 7.4
 */
 
 /*


### PR DESCRIPTION
`readme.txt` has declared `Requires PHP: 7.4` for a while, but the plugin header did not.

The two are not interchangeable. WordPress enforces the **header** — since 5.5 it blocks activation and updates on an incompatible PHP version — while the readme only feeds the wp.org directory listing. Without the header a user on PHP 7.2 can activate and only discover the problem when something fatals.

One line, matching what `readme.txt` already claims:

```
Requires PHP: 7.4
```

Verified: `get_plugin_data()` returns `RequiresPHP=7.4`, the plugin still activates, `/wp-json/` returns 200.

Same change on Pro: weDevsOfficial/wedocs-pro#415, where the gap let a PHP 8.2-only syntax error reach a live 8.1 site (weDevsOfficial/wedocs-pro#413).