### PR TITLE
fix: let the filter decide the outcome, not phpcs's exit code

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Detect coding standard violations
         if: steps.changes.outputs.files != ''
         run: |
-          set -o pipefail
-          phpcs --standard=phpcs.xml.dist ${{ steps.changes.outputs.files }} -q --report=json \
-            | php bin/phpcs-changed-lines.php "$(git rev-parse HEAD^1)"
+          # phpcs exits non-zero whenever the FILES hold violations, including
+          # pre-existing ones on lines this change never touched. Its status is
+          # therefore not the signal we want, so it is discarded here and the
+          # filter below decides the outcome from the changed lines alone.
+          phpcs --standard=phpcs.xml.dist ${{ steps.changes.outputs.files }} -q --report=json > phpcs-report.json || true
+          php bin/phpcs-changed-lines.php "$(git rev-parse HEAD^1)" < phpcs-report.json


### PR DESCRIPTION
With `set -o pipefail` the job failed on **phpcs's own** status. phpcs exits non-zero whenever the *files* contain violations, including pre-existing ones on lines the change never touched, which is exactly the signal the line filter exists to discard.

wedocs-plugin#324 showed it plainly. The filter did its job and passed:

```
PHPCS: 10 finding(s) on changed lines, 0 of them errors (250 findings in these files overall).
```

and the job was still marked `FAILURE`, because phpcs had already exited 2 on the 250 findings in the files overall.

phpcs's status is now discarded explicitly and `bin/phpcs-changed-lines.php` decides the outcome on its own.

https://claude.ai/code/session_019wvVjJ8agR8TWAVrrKVESH