### PR TITLE
fix: link the FAQ documentation from the FAQ empty state

### DIFF
--- a/src/faq/components/EmptyFaq.js
+++ b/src/faq/components/EmptyFaq.js
@@ -63,10 +63,18 @@ const EmptyFaq = ( { onGroupCreated } ) => {
                                 </defs>
                             </svg>
                             <p className="text-[#3B3F4A] font-bold text-2xl mx-auto">
-                                { __( 'Get started by creating your first FAQ group', 'wedocs' ) }
+                                { __( 'Get started by creating FAQs for your site', 'wedocs' ) }
                             </p>
                             <p className="text-[#666B79] text-lg mx-auto mt-2">
-                                { __( 'Group your frequently asked questions so users can find answers quickly.', 'wedocs' ) }
+                                <a
+                                    href="https://wedocs.co/docs/wedocs/faq_feature/"
+                                    className="text-[#0043FF] !shadow-none"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
+                                    { __( 'Learn more ', 'wedocs' ) }
+                                </a>
+                                { __( 'how to manage FAQs', 'wedocs' ) }
                             </p>
                         </h2>
                         <AddFaqGroupModal onGroupCreated={ onGroupCreated } className="inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-6 py-2.5 text-base text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">


### PR DESCRIPTION
Fixes weDevsOfficial/wedocs-pro#425.

The FAQ admin empty state had no link to its documentation. Every other empty state in the plugin has one:

| screen | links to |
|---|---|
| `EmptyDocs.js` | `how-to/how-to-create-a-doc/` |
| `Migrations/index.js` | the BetterDocs migration guide |
| `Settings/GeneralSettings.js` | `shortcodes/` |
| `Premium/index.js` | `dokan-support-for-wedocs/` |
| **`EmptyFaq.js`** | **nothing** |

The FAQ documentation exists and is live (`https://wedocs.co/docs/wedocs/faq_feature/` returns 200, titled "FAQ Feature"), it just was not referenced anywhere in either plugin.

### Before

```
Get started by creating your first FAQ group
Group your frequently asked questions so users can find answers quickly.
```

### After

```
Get started by creating FAQs for your site
Learn more how to manage FAQs
```

with **Learn more** linking to the FAQ docs. The markup mirrors `EmptyDocs.js` exactly, same link classes, `target` and `rel`.

Verified in the build: the URL and the new string land in `assets/build/faq.js` (the FAQ entry point, not `index.js`), and the old copy is gone.

The FAQ builder shipped in Free 2.5.0, so this has been missing since the feature landed.

https://claude.ai/code/session_019wvVjJ8agR8TWAVrrKVESH