### PR TITLE
fix: match the MCP preview copy to Pro

### DIFF
--- a/src/components/ProPreviews/McpSettings.js
+++ b/src/components/ProPreviews/McpSettings.js
@@ -60,7 +60,7 @@ const McpSettings = () => {
 				>
 					<p className="mt-0 mb-6 text-sm leading-relaxed text-gray-500 max-w-3xl">
 						{ __(
-							'Let AI assistants such as Claude and ChatGPT read and write your documentation directly, over the Model Context Protocol. Access runs through a revocable connection token or a one-time sign-in, and every action is performed as the person who granted it.',
+							'Let AI assistants like Claude or ChatGPT generate your articles, tags, changelog, glossary or FAQs.',
 							'wedocs'
 						) }
 					</p>


### PR DESCRIPTION
Follows weDevsOfficial/wedocs-pro#426, which rewrote the MCP description in the real Pro panel. This is the Free upsell preview of that same panel, so it should read the same.

Before:

> Let AI assistants such as Claude and ChatGPT read and write your documentation directly, over the Model Context Protocol. Access runs through a revocable connection token or a one-time sign-in, and every action is performed as the person who granted it.

After:

> Let AI assistants like Claude or ChatGPT generate your articles, tags, changelog, glossary or FAQs.

Verified in the build: the new string lands in `assets/build/index.js` and the old one is gone from every bundle.

https://claude.ai/code/session_019wvVjJ8agR8TWAVrrKVESH